### PR TITLE
Now we prewarm the bundle cache by downloading the bundle before running the applications in debug mode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
 				"--extensionDevelopmentPath=${workspaceRoot}"
 			],
 			"sourceMaps": true,
-			"outDir": "./out",
+			"outDir": "${workspaceRoot}/out",
             "preLaunchTask": "build"
 		},
 		{


### PR DESCRIPTION
- We download index.android.bundle or index.ios.bundle before running the app in debug mode
- Extracted packager port into a variable, for easier testing in shared machines
