### PR TITLE
Adding in iOS device compilation and launch

### DIFF
--- a/src/debugger/ios/compiler.ts
+++ b/src/debugger/ios/compiler.ts
@@ -9,11 +9,9 @@ import {Xcodeproj} from "./xcodeproj";
 
 export class Compiler {
     private projectRoot: string;
-    private simulator: boolean;
 
-    constructor(projectRoot: string, simulator: boolean) {
+    constructor(projectRoot: string) {
         this.projectRoot = projectRoot;
-        this.simulator = simulator;
     }
 
     public compile(): Q.Promise<void> {
@@ -26,9 +24,6 @@ export class Compiler {
         Return the appropriate arguments for compiling a react native project
     */
     private xcodeBuildArguments(): Q.Promise<string[]> {
-        if (this.simulator) {
-            return Q.reject<string[]>(new Error("Error: Compiling for simulator; should be using 'react-native run-ios' instead"));
-        }
         return new Xcodeproj().findXcodeprojFile(this.projectRoot).then((projectFile: string) => {
             const projectName = path.basename(projectFile, path.extname(projectFile));
             return [

--- a/src/debugger/ios/deviceDeployer.ts
+++ b/src/debugger/ios/deviceDeployer.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
+import * as path from "path";
+import * as Q from "q";
 
+import {CommandExecutor} from "../../utils/commands/commandExecutor";
+import {Log} from "../../utils/commands/log";
+import {Xcodeproj} from "./xcodeproj";
 
 export class DeviceDeployer {
     private projectRoot: string;
@@ -11,6 +16,17 @@ export class DeviceDeployer {
     }
 
     public deploy(): Q.Promise<void> {
-        throw new Error("Not Implemented");
+        return new Xcodeproj().findXcodeprojFile(this.projectRoot).then((projectFile: string) => {
+            const projectName = path.basename(projectFile, path.extname(projectFile));
+            const pathToCompiledApp = path.join(this.projectRoot, "ios", "build",
+                "Build", "Products", "Debug-iphoneos", `${projectName}.app`);
+            return new CommandExecutor(this.projectRoot)
+                .spawnAndWaitForCompletion("ideviceinstaller", ["-i", pathToCompiledApp]).catch((err) => {
+                    if (err.code === "ENOENT") {
+                        Log.logError("Unable to find ideviceinstaller. Please make sure to install Homebrew (http://brew.sh) and then 'brew install ideviceinstaller'");
+                    }
+                    throw err;
+                });
+        });
     }
 }

--- a/src/debugger/ios/deviceRunner.ts
+++ b/src/debugger/ios/deviceRunner.ts
@@ -1,16 +1,284 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
+import {ChildProcess} from "child_process";
+import * as net from "net";
+import * as Q from "q";
 
+import {Node} from "../../utils/node/node";
+import {PlistBuddy} from "./plistBuddy";
 
 export class DeviceRunner {
     private projectRoot: string;
+    private nativeDebuggerProxyInstance: ChildProcess;
 
     constructor(projectRoot: string) {
         this.projectRoot = projectRoot;
+        process.on("exit", () => this.cleanup());
     }
 
     public run(): Q.Promise<void> {
-        throw new Error("Not Implemented");
+        const proxyPort = 9999;
+        const appLaunchStepTimeout = 5000;
+        return new PlistBuddy().getBundleId(this.projectRoot, /*simulator=*/false)
+            .then((bundleId: string) => this.getPathOnDevice(bundleId))
+            .then((path: string) =>
+                this.startNativeDebugProxy(proxyPort).then(() =>
+                    this.startAppViaDebugger(proxyPort, path, appLaunchStepTimeout)
+                )
+            )
+            .then(() => { });
+    }
+
+    private cleanup(): void {
+        if (this.nativeDebuggerProxyInstance) {
+            this.nativeDebuggerProxyInstance.kill("SIGHUP");
+            this.nativeDebuggerProxyInstance = null;
+        }
+    }
+
+    private startNativeDebugProxy(proxyPort: number): Q.Promise<void> {
+        this.cleanup();
+
+        return this.mountDeveloperImage().then(function(): Q.Promise<void> {
+            const {spawnedProcess} = new Node.ChildProcess().spawn("idevicedebugserverproxy", [proxyPort.toString()]);
+            this.nativeDebuggerProxyInstance = spawnedProcess;
+            const deferred = Q.defer<ChildProcess>();
+
+            spawnedProcess.on("error", (err: Error) => {
+                deferred.reject(err);
+            });
+
+            // Allow 200ms for the spawn to error out
+            return Q.delay(200);
+        });
+    }
+
+    private mountDeveloperImage(): Q.Promise<void> {
+        return this.getDiskImage().then(function(path: string): Q.Promise<void> {
+            const imagemounter = new Node.ChildProcess().spawn("ideviceimagemounter", [path]).spawnedProcess;
+            const deferred = Q.defer<void>();
+            let stdout: string = "";
+            imagemounter.stdout.on("data", function(data: any): void {
+                stdout += data.toString();
+            });
+            imagemounter.on("exit", function(code: number): void {
+                if (code !== 0) {
+                    if (stdout.indexOf("Error:") !== -1) {
+                        deferred.resolve(void 0); // Technically failed, but likely caused by the image already being mounted.
+                    } else if (stdout.indexOf("No device found, is it plugged in?") !== -1) {
+                        deferred.reject("Unable to find device. Is the device plugged in?");
+                    }
+
+                    deferred.reject("Unable to mount developer disk image.");
+                } else {
+                    deferred.resolve(void 0);
+                }
+            });
+            imagemounter.on("error", function(err: any): void {
+                deferred.reject(err);
+            });
+            return deferred.promise;
+        });
+    }
+
+    private getDiskImage(): Q.Promise<string> {
+        const nodeChildProcess = new Node.ChildProcess();
+        // Attempt to find the OS version of the iDevice, e.g. 7.1
+        const versionInfo = nodeChildProcess.exec("ideviceinfo -s -k ProductVersion").outcome.then((stdout: Buffer) => {
+            return stdout.toString().trim().substring(0, 3); // Versions for DeveloperDiskImage seem to be X.Y, while some device versions are X.Y.Z
+            // NOTE: This will almost certainly be wrong in the next few years, once we hit version 10.0
+        }, function(): string {
+            throw new Error("Unable to get device OS version");
+        });
+
+        // Attempt to find the path where developer resources exist.
+        const pathInfo = nodeChildProcess.exec("xcrun -sdk iphoneos --show-sdk-platform-path").outcome.then((stdout: Buffer) => {
+            return stdout.toString().trim();
+        });
+
+        // Attempt to find the developer disk image for the appropriate
+        return Q.all([versionInfo, pathInfo]).spread<string>(function(version: string, sdkpath: string): Q.Promise<string> {
+            const find = nodeChildProcess.spawn("find", [sdkpath, "-path", "*" + version + "*", "-name", "DeveloperDiskImage.dmg"]).spawnedProcess;
+            const deferred = Q.defer<string>();
+
+            find.stdout.on("data", function(data: any): void {
+                const dataStr: string = data.toString();
+                const path: string = dataStr.split("\n")[0].trim();
+                if (!path) {
+                    deferred.reject("Unable to find developer disk image");
+                } else {
+                    deferred.resolve(path);
+                }
+            });
+            find.on("exit", function(code: number): void {
+                deferred.reject("Unable to find developer disk image");
+            });
+
+            return deferred.promise;
+        });
+    }
+
+    private getPathOnDevice(packageId: string): Q.Promise<string> {
+        const nodeChildProcess = new Node.ChildProcess();
+        const nodeFileSystem = new Node.FileSystem();
+        return nodeChildProcess.execToString("ideviceinstaller -l -o xml > /tmp/$$.ideviceinstaller && echo /tmp/$$.ideviceinstaller")
+            .catch(function(err: any): any {
+                if (err.code === "ENOENT") {
+                    throw new Error("Unable to find ideviceinstaller.");
+                }
+                throw err;
+            }).then((stdout: string): Q.Promise<string> => {
+                // First find the path of the app on the device
+                let filename: string = stdout.trim();
+                if (!/^\/tmp\/[0-9]+\.ideviceinstaller$/.test(filename)) {
+                    throw new Error("Unable to list installed applications on device");
+                }
+
+                const plistBuddy = new PlistBuddy();
+                // Search thrown the unknown-length array until we find the package
+                const findPackageEntry = (index: number): Q.Promise<string> => {
+                    return plistBuddy.readPlistProperty(filename, `:${index}:CFBundleIdentifier`)
+                        .then((bundleId: string) => {
+                            if (bundleId === packageId) {
+                                return plistBuddy.readPlistProperty(filename, `:${index}:Path`);
+                            }
+                            return findPackageEntry(index + 1);
+                        });
+                };
+
+                return findPackageEntry(0)
+                    .finally(() => {
+                        nodeFileSystem.unlink(filename);
+                    }).catch((): string => {
+                        throw new Error("Application not installed on the device");
+                    });
+            });
+    }
+
+    // Attempt to start the app on the device, using the debug server proxy on a given port.
+    // Returns a socket speaking remote gdb protocol with the debug server proxy.
+    public startAppViaDebugger(portNumber: number, packagePath: string, appLaunchStepTimeout: number): Q.Promise<string> {
+        const encodedPath: string = this.encodePath(packagePath);
+
+        // We need to send 3 messages to the proxy, waiting for responses between each message:
+        // A(length of encoded path),0,(encoded path)
+        // Hc0
+        // c
+        // We expect a '+' for each message sent, followed by a $OK#9a to indicate that everything has worked.
+        // For more info, see http://www.opensource.apple.com/source/lldb/lldb-167.2/docs/lldb-gdb-remote.txt
+        const socket: net.Socket = new net.Socket();
+        let initState: number = 0;
+        let endStatus: number = null;
+        let endSignal: number = null;
+
+        const deferred1: Q.Deferred<net.Socket> = Q.defer<net.Socket>();
+        const deferred2: Q.Deferred<net.Socket> = Q.defer<net.Socket>();
+        const deferred3: Q.Deferred<net.Socket> = Q.defer<net.Socket>();
+
+        socket.on("data", function(data: any): void {
+            data = data.toString();
+            while (data[0] === "+") { data = data.substring(1); }
+            // Acknowledge any packets sent our way
+            if (data[0] === "$") {
+                socket.write("+");
+                if (data[1] === "W") {
+                    // The app process has exited, with hex status given by data[2-3]
+                    let status: number = parseInt(data.substring(2, 4), 16);
+                    endStatus = status;
+                    socket.end();
+                } else if (data[1] === "X") {
+                    // The app rocess exited because of signal given by data[2-3]
+                    let signal: number = parseInt(data.substring(2, 4), 16);
+                    endSignal = signal;
+                    socket.end();
+                } else if (data.substring(1, 3) === "OK") {
+                    // last command was received OK;
+                    if (initState === 1) {
+                        deferred1.resolve(socket);
+                    } else if (initState === 2) {
+                        deferred2.resolve(socket);
+                    }
+                } else if (data[1] === "O") {
+                    // STDOUT was written to, and the rest of the input until reaching a "#" is a hex-encoded string of that output
+                    if (initState === 3) {
+                        deferred3.resolve(socket);
+                        initState++;
+                    }
+                } else if (data[1] === "E") {
+                    // An error has occurred, with error code given by data[2-3]: parseInt(data.substring(2, 4), 16)
+                    deferred1.reject("Unable to launch application.");
+                    deferred2.reject("Unable to launch application.");
+                    deferred3.reject("Unable to launch application.");
+                }
+            }
+        });
+
+        socket.on("end", function(): void {
+            deferred1.reject("Unable to launch application.");
+            deferred2.reject("Unable to launch application.");
+            deferred3.reject("Unable to launch application.");
+        });
+
+        socket.on("error", function(err: Error): void {
+            deferred1.reject(err);
+            deferred2.reject(err);
+            deferred3.reject(err);
+        });
+
+        socket.connect(portNumber, "localhost", () => {
+            // set argument 0 to the (encoded) path of the app
+            const cmd: string = this.makeGdbCommand("A" + encodedPath.length + ",0," + encodedPath);
+            initState++;
+            socket.write(cmd);
+            setTimeout(function(): void {
+                deferred1.reject("Timeout launching application. Is the device locked?");
+            }, appLaunchStepTimeout);
+        });
+
+        return deferred1.promise.then((sock: net.Socket): Q.Promise<net.Socket> => {
+            // Set the step and continue thread to any thread
+            const cmd: string = this.makeGdbCommand("Hc0");
+            initState++;
+            sock.write(cmd);
+            setTimeout(function(): void {
+                deferred2.reject("Timeout launching application. Is the device locked?");
+            }, appLaunchStepTimeout);
+            return deferred2.promise;
+        }).then((sock: net.Socket): Q.Promise<net.Socket> => {
+            // Continue execution; actually start the app running.
+            const cmd: string = this.makeGdbCommand("c");
+            initState++;
+            sock.write(cmd);
+            setTimeout(function(): void {
+                deferred3.reject("Timeout launching application. Is the device locked?");
+            }, appLaunchStepTimeout);
+            return deferred3.promise;
+        }).then(() => packagePath);
+    }
+
+    private encodePath(packagePath: string): string {
+        // Encode the path by converting each character value to hex
+        return packagePath.split("").map((c: string) => c.charCodeAt(0).toString(16)).join("").toUpperCase();
+    }
+
+    private makeGdbCommand(command: string): string {
+        let commandString: string = `$${command}#`;
+        let stringSum: number = 0;
+        for (let i: number = 0; i < command.length; i++) {
+            stringSum += command.charCodeAt(i);
+        }
+
+        /* tslint:disable:no-bitwise */
+        // We need some bitwise operations to calculate the checksum
+        stringSum = stringSum & 0xFF;
+        /* tslint:enable:no-bitwise */
+        let checksum: string = stringSum.toString(16).toUpperCase();
+        if (checksum.length < 2) {
+            checksum = "0" + checksum;
+        }
+
+        commandString += checksum;
+        return commandString;
     }
 }

--- a/src/debugger/ios/iOSPlatform.ts
+++ b/src/debugger/ios/iOSPlatform.ts
@@ -37,7 +37,7 @@ export class IOSPlatform implements IAppPlatform {
         }
 
         // TODO: This is currently a stub, device debugging is not yet implemented
-        return new Compiler(this.projectPath, this.isSimulator).compile().then(() => {
+        return new Compiler(this.projectPath).compile().then(() => {
             return new DeviceDeployer(this.projectPath).deploy();
         }).then(() => {
             return new DeviceRunner(this.projectPath).run();

--- a/src/debugger/ios/plistBuddy.ts
+++ b/src/debugger/ios/plistBuddy.ts
@@ -28,6 +28,10 @@ export class PlistBuddy {
         ).then(() => {});
     }
 
+    public readPlistProperty(plistFile: string, property: string): Q.Promise<string> {
+        return this.invokePlistBuddy(`Print ${property}`, plistFile);
+    }
+
     private invokePlistBuddy(command: string, plistFile: string): Q.Promise<string> {
         return new Node.ChildProcess().exec(`${PlistBuddy.plistBuddyExecutable} -c '${command}' '${plistFile}'`).outcome.then((result: Buffer) => {
             return result.toString().trim();

--- a/src/utils/commands/commandExecutor.ts
+++ b/src/utils/commands/commandExecutor.ts
@@ -71,6 +71,7 @@ export class CommandExecutor {
             },
                 (reason) => {
                     Log.commandFailed(commandWithArgs, reason, outputChannel);
+                    throw reason;
                 });
         });
     }

--- a/src/utils/node/fileSystem.ts
+++ b/src/utils/node/fileSystem.ts
@@ -61,6 +61,10 @@ export class FileSystem {
         return Q.nfcall<void>(fs.writeFile, filename, data);
     }
 
+    public unlink(filename: string): Q.Promise<void> {
+        return Q.nfcall<void>(fs.unlink, filename);
+    }
+
     public findFilesByExtension(folder: string, extension: string): Q.Promise<string[]> {
         return Q.nfcall(fs.readdir, folder).then((files: string[]) => {
             const extFiles = files.filter((file: string) => path.extname(file) === `.${extension}`);


### PR DESCRIPTION
Note that this is very much not a hands-free experience: With this PR it is possible to build, deploy, and launch to an iOS device, but there are a couple of manual user steps required for the app to actually work:
1. The user needs to modify ios/<appname>/AppDelegate.m to point to the address of the host mac as seen by the iOS device instead of "localhost"
2. The user needs to modify node_modules/react-native/Libraries/WebSocket/RCTWebSocketExecutor.m to replace localhost with the address of the host mac in another string
3. Once the app is launched, the user needs to shake the device and select "debug in Chrome / JavaScript" to enable debugging

If everything is configured correctly then debugging should work here. However this scenario seems unstable and will often have a big red error screen pop up, complaining about things such as the handling of touch events etc. 
