### PR TITLE
Added a try and catch to the code where we send messages to the RN App

### DIFF
--- a/src/debugger/appWorker.ts
+++ b/src/debugger/appWorker.ts
@@ -215,8 +215,14 @@ export class MultipleLifetimesAppWorker {
     }
 
     private sendMessageToApp(message: any) {
-        let stringified = JSON.stringify(message);
-        Log.logInternalMessage(LogLevel.Trace, "To RN APP: " + stringified);
-        this.socketToApp.send(stringified);
+        let stringified: string = null;
+        try {
+            stringified = JSON.stringify(message);
+            Log.logInternalMessage(LogLevel.Trace, "To RN APP: " + stringified);
+            this.socketToApp.send(stringified);
+        } catch (exception) {
+            let messageToShow = stringified || ("" + message); // Try to show the stringified version, but show the toString if unavailable
+            printDebuggingFatalError(`Failed to send message to the React Native app. Message:\n${messageToShow}`, exception);
+        }
     }
 }


### PR DESCRIPTION
It seems that it's possible that the socket gets closed while we are processing a message, and that makes our debugging crashes. This try and catch will help keep the debugger running if that happens, and let the user try Reloading JS to see if that solves the issue.
