### PR TITLE
Adding exclude node_modules to tsconfig

### DIFF
--- a/src/rn-extension.ts
+++ b/src/rn-extension.ts
@@ -69,8 +69,11 @@ function setupReactNativeIntellisense(): void {
         return;
     }
 
-    // Enable JavaScript intellisense through Salsa language service
-    TsConfigHelper.allowJs(true).done();
+    TsConfigHelper.allowJs(true)
+    .then(function() {
+        return TsConfigHelper.addExcludePaths(["node_modules"]);
+    })
+    .done();
 
     let reactTypingsSource = path.resolve(__dirname, "..", "ReactTypings");
     let reactTypingsDest = path.resolve(vscode.workspace.rootPath, ".vscode", "typings");

--- a/src/utils/tsconfigHelper.ts
+++ b/src/utils/tsconfigHelper.ts
@@ -61,4 +61,28 @@ export class TsConfigHelper {
             return TsConfigHelper.writeConfigJson(tsConfigJson);
         });
     }
+
+    /**
+     * Add directories to be excluded by the Typescript compiler.
+     */
+    public static addExcludePaths(excludePaths: string[]): Q.Promise<void> {
+        return TsConfigHelper.readConfigJson()
+        .then(function(tsConfigJson: any) {
+            let currentExcludes: string[] = tsConfigJson.exclude || [];
+            let isDirty: boolean = false;
+
+            excludePaths.forEach(function(exclude: string){
+                if (currentExcludes.indexOf(exclude) < 0) {
+                    currentExcludes.push(exclude);
+                    isDirty = true;
+                }
+            });
+
+            if (isDirty) {
+                tsConfigJson.exclude = currentExcludes;
+
+                return TsConfigHelper.writeConfigJson(tsConfigJson);
+            }
+        });
+    }
 }


### PR DESCRIPTION
## Summary

To workaround https://github.com/Microsoft/TypeScript/issues/6673 we need to add "node_modules" to the list of excludes in the tsconfig.json we are generating.
