### PR TITLE
Reverting version of vsce

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "devDependencies": {
         "vscode": "^0.10.7",
         "typescript": "^1.7.5",
-        "vsce": "^1.0.0",
+        "vsce": "1.0.0",
         "run-sequence": "^1.1.5",
         "gulp": "^3.9.0",
         "gulp-mocha": "^2.1.3",


### PR DESCRIPTION
Version 1.1.0 of vsce does not deal properly with nested node dependencies. Reverting back to 1.0.0 appears to fix the issue for now.

Issue https://github.com/Microsoft/vscode-vsce/issues/64 tracks a fix for vsce
