### PR TITLE
Fixing a race condition

### DIFF
--- a/src/debugger/ios/iOSPlatform.ts
+++ b/src/debugger/ios/iOSPlatform.ts
@@ -91,10 +91,10 @@ export class IOSPlatform implements IAppPlatform {
                 // down before writing to the file.
                 const childProcess = new ChildProcess();
 
-                return childProcess.exec("xcrun simctl spawn booted launchctl list").outcome.then((buffer: Buffer) => {
+                return childProcess.execToString("xcrun simctl spawn booted launchctl list").then((output: string) => {
                     // Try to find an entry that looks like UIKitApplication:com.example.myApp[0x4f37]
                     const regex = new RegExp(`(\\S+${bundleId}\\S+)`);
-                    const match = regex.exec(buffer.toString());
+                    const match = regex.exec(output);
 
                     // If we don't find a match, the app must not be running and so we do not need to close it
                     if (match) {

--- a/src/debugger/ios/iOSPlatform.ts
+++ b/src/debugger/ios/iOSPlatform.ts
@@ -86,6 +86,9 @@ export class IOSPlatform implements IAppPlatform {
         ]).spread((debugModeSetting: string, bundleId: string) => {
             if (debugModeSetting !== IOSDebugModeManager.WEBSOCKET_EXECUTOR_NAME) {
                 // Debugging must still be enabled
+                // We enable debugging by writing to a plist file that backs a NSUserDefaults object,
+                // but that file is written to by the app on occasion. To avoid races, we shut the app
+                // down before writing to the file.
                 const childProcess = new ChildProcess();
 
                 return childProcess.exec("xcrun simctl spawn booted launchctl list").outcome.then((buffer: Buffer) => {


### PR DESCRIPTION
When enabling debug mode on the iOS simulator, we attempt to modify a plist file backing an NSUserDefaults object. This plist file is written to by the app at various times, and this would sometimes overwrite our change.

With this fix, we start the app to ensure the file is created, then we stop the app to avoid a race condition. We need to wait a moment to ensure that the app is completely closed, then we write to the file and restart the app. Simply relaunching the app is not sufficient, we need to re-install the app or it does not pick up the changes.

Fixes #44 