### PR TITLE
Adding a step to check imports use correct names

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,7 +21,7 @@ var sources = [
 // TODO: The file property should point to the generated source (this implementation adds an extra folder to the path)
 // We should also make sure that we always generate urls in all the path properties (We shouldn't have \\s. This seems to
 // be an issue on Windows platforms)
-gulp.task('build', function () {
+gulp.task('build', ['checkImports'], function () {
     var tsProject = ts.createProject('tsconfig.json');
     return tsProject.src()
         .pipe(sourcemaps.init())
@@ -64,6 +64,22 @@ function test() {
 
 gulp.task('build-test', ['build'], test);
 gulp.task('test', test);
+
+gulp.task('checkImports', function (cb) {
+    var checkProcess = child_process.fork(path.join(__dirname, "tools", "checkCasing.js"),
+        {
+            cwd: path.resolve(__dirname, "src"),
+            stdio: "inherit"
+        });
+    checkProcess.on("error", cb);
+    checkProcess.on("exit", function (code) {
+        if (code) {
+            cb(new Error("Mismatches found in import casing"));
+        } else {
+            cb();
+        }
+    });
+});
 
 gulp.task('watch-build-test', ['build', 'build-test'], function () {
     return gulp.watch(sources, ['build', 'build-test']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -72,8 +72,8 @@ gulp.task('checkImports', function (cb) {
             stdio: "inherit"
         });
     checkProcess.on("error", cb);
-    checkProcess.on("exit", function (code) {
-        if (code) {
+    checkProcess.on("exit", function (code, signal) {
+        if (code || signal) {
             cb(new Error("Mismatches found in import casing"));
         } else {
             cb();

--- a/tools/checkCasing.js
+++ b/tools/checkCasing.js
@@ -1,0 +1,37 @@
+var fs = require("fs");
+var path = require("path");
+var os = require("os");
+var child_process = require("child_process");
+
+// Recursively find all instances of 'import [...] from "[...]";'
+if (os.platform() === "win32") {
+    child_process.exec("findstr /sir /C:\"import.*from\" *.ts", parseOutput);
+} else {
+    child_process.exec("grep -Ri 'import.*from' .", parseOutput);
+}
+
+function parseOutput(err, out, stderr) {
+    // Extract out the filename containing the match,
+    // and the relative path of the file it is searching for
+    var regex = /(\s|^)([^\n:]*):.*from ["'](\.[^"']*)["'];/g;
+    var imports = [];
+    out.replace(regex, function (all, _, file, from) {
+        imports.push({ path: file, relative: from });
+    });
+    checkImports(imports);
+}
+
+function checkImports(imports) {
+    // Check to see if the import references a source file
+    // with an exact match of a name, and complain otherwise
+    imports.map(function (i) {
+        i.resolved = path.resolve(path.dirname(i.path), i.relative + ".ts");
+        return i;
+    }).filter(function (i) {
+        var entries = fs.readdirSync(path.dirname(i.resolved));
+        return entries.indexOf(path.basename(i.resolved)) === -1;
+    }).forEach(function (i) {
+        console.log("Missing file for import in " + i.path + ": " + i.relative);
+        process.exitCode = 1;
+    });
+}


### PR DESCRIPTION
Since we've had a few instances of capitalisation typos in imports, I'm adding this build step to automatically check the source code. It goes over all `.ts` files under `src` and checks all `import [...] from "[...]";` lines. If the import is a relative path, it ensures that the destination is a `.ts` file at that location with that exact name.