### PR TITLE
Bugfix - Debugger URL query parameter requirements

### DIFF
--- a/src/debugger/appWorker.ts
+++ b/src/debugger/appWorker.ts
@@ -183,7 +183,7 @@ export class MultipleLifetimesAppWorker {
     }
 
     private debuggerProxyUrl() {
-        return `ws://${Packager.HOST}/debugger-proxy`;
+        return `ws://${Packager.HOST}/debugger-proxy?role=debugger&name=vscode`;
     }
 
     private onSocketOpened() {


### PR DESCRIPTION
Described in #91, https://github.com/facebook/react-native/commit/64d56f34b779de94f251f4b443463cbfe790912d introduces a breaking change that requires `role` and `name` query parameters as part of the /debugger-proxy url. This is a breaking change introduced in `0.21.0-rc` of React Native. This is a required patch to retain compatibility in the upcoming full release of `0.21.0`.

An example can be found in https://github.com/facebook/react-native/commit/64d56f34b779de94f251f4b443463cbfe790912d#diff-6ec5b06d4c2f30dd3f47c1eaaee08c3dR28 of connecting with the new query parameters