### PR TITLE
Now we support RN 0.21-rc

### DIFF
--- a/src/debugger/appWorker.ts
+++ b/src/debugger/appWorker.ts
@@ -181,7 +181,7 @@ export class MultipleLifetimesAppWorker {
     }
 
     private debuggerProxyUrl() {
-        return `ws://${Packager.HOST}/debugger-proxy`;
+        return `ws://${Packager.HOST}/debugger-proxy?role=debugger&name=React%20Native%20Tools`;
     }
 
     private onSocketOpened() {


### PR DESCRIPTION
In this commit: https://github.com/facebook/react-native/commit/64d56f34b779de94f251f4b443463cbfe790912d
They added a required role parameter to the url of the web socket with the packager/React-Native App.

This code seems to work both with 0.21-rc and 0.19.

This will solve: https://github.com/Microsoft/vscode-react-native/issues/91