### PR TITLE
Now the launch when multiple devices are available, and stop on Androiderror features work correctly together

### DIFF
--- a/SampleApplication/package.json
+++ b/SampleApplication/package.json
@@ -1,11 +1,11 @@
 {
-    "name": "SampleApplication",
-    "version": "0.0.1",
-    "private": true,
-    "scripts": {
-        "start": "node node_modules/react-native/local-cli/cli.js start"
-    },
-    "dependencies": {
-        "react-native": "^0.19.0"
-    }
+  "name": "SampleApplication",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "node node_modules/react-native/local-cli/cli.js start"
+  },
+  "dependencies": {
+    "react-native": "^0.19.0"
+  }
 }

--- a/src/debugger/android/androidPlatform.ts
+++ b/src/debugger/android/androidPlatform.ts
@@ -19,17 +19,21 @@ import {Package} from "../../common/node/package";
 export class AndroidPlatform implements IAppPlatform {
     private extensionMessageSender: ExtensionMessageSender;
 
+    private static MULTIPLE_DEVICES_ERROR = "error: more than one device/emulator";
+
     // We should add the common Android build/run erros we find to this list
     private static RUN_ANDROID_FAILURE_PATTERNS: PatternToFailure = {
         "Failed to install on any devices": "Could not install the app on any available device. Make sure you have a correctly"
          + " configured device or emulator running. See https://facebook.github.io/react-native/docs/android-setup.html",
     "com.android.ddmlib.ShellCommandUnresponsiveException": "An Android shell command timed-out. Please retry the operation.",
-    "Android project not found": "Android project not found." };
+    "Android project not found": "Android project not found.",
+    "error: more than one device/emulator": AndroidPlatform.MULTIPLE_DEVICES_ERROR };
 
     private static RUN_ANDROID_SUCCESS_PATTERNS: string[] = ["BUILD SUCCESSFUL", "Starting the app", "Starting: Intent"];
 
     private debugTarget: string;
-    private packageName: string;
+    private devices: IDevice[];
+    private packageName: Q.Promise<string>;
     private deviceHelper: DeviceHelper;
 
     constructor({ extensionMessageSender = new ExtensionMessageSender()} = {}) {
@@ -38,7 +42,6 @@ export class AndroidPlatform implements IAppPlatform {
     }
 
     public runApp(runOptions: IRunOptions): Q.Promise<void> {
-        let pkg = new Package(runOptions.projectRoot);
         let cexec = new CommandExecutor(runOptions.projectRoot);
 
         const runAndroidSpawn = cexec.spawnChildReactCommandProcess("run-android");
@@ -48,31 +51,37 @@ export class AndroidPlatform implements IAppPlatform {
             () =>
                 Q(AndroidPlatform.RUN_ANDROID_FAILURE_PATTERNS)).process(runAndroidSpawn);
 
-        return output
-            .then(() => pkg.name())
-            .then(appName => new PackageNameResolver(appName).resolvePackageName(runOptions.projectRoot))
-            .then(packageName => {
-                this.packageName = packageName;
-                return this.deviceHelper.getConnectedDevices()
-                    .then((devices: IDevice[]) => {
-                        if (devices.length > 1) {
-                            /* more than one device or emulator */
-                            this.debugTarget = this.getTargetEmulator(runOptions, devices);
-                            if (this.debugTarget) {
-                                /* Launching is needed only if we have more than one device active */
-                                return this.deviceHelper.launchApp(runOptions.projectRoot, packageName, this.debugTarget);
-                            }
-                        } else if (devices.length === 1) {
-                            this.debugTarget = devices[0].id;
-                        }
-                    });
+        return output.finally(() =>
+            this.deviceHelper.getConnectedDevices().then(devices => {
+                this.devices = devices;
+                this.debugTarget = this.getTargetEmulator(runOptions, devices);
+            }))
+            .catch(reason => {
+                if (reason.message === AndroidPlatform.MULTIPLE_DEVICES_ERROR && this.devices.length > 1 && this.debugTarget) {
+                    /* If it failed due to multiple devices, we'll apply this workaround to make it work anyways */
+                    return this.getPackageName(runOptions.projectRoot).then(packageName =>
+                        this.deviceHelper.launchApp(runOptions.projectRoot, packageName, this.debugTarget));
+                } else {
+                    return Q.reject<void>(reason);
+                }
             }).then(() =>
                 this.startMonitoringLogCat(runOptions.logCatArguments).catch(error => // The LogCatMonitor failing won't stop the debugging experience
                     Log.logWarning("Couldn't start LogCat monitor", error)));
     }
 
     public enableJSDebuggingMode(runOptions: IRunOptions): Q.Promise<void> {
-        return this.deviceHelper.reloadAppInDebugMode(runOptions.projectRoot, this.packageName, this.debugTarget);
+        return this.getPackageName(runOptions.projectRoot).then(packageName =>
+            this.deviceHelper.reloadAppInDebugMode(runOptions.projectRoot, packageName, this.debugTarget));
+    }
+
+    // Package name is only used when we have multiple devices, or we go into debugging mode, so we initialize it lazily
+    private getPackageName(projectRoot: string): Q.Promise<string> {
+        if (!this.packageName) {
+            this.packageName = new Package(projectRoot).name().then(appName =>
+                new PackageNameResolver(appName).resolvePackageName(projectRoot));
+        }
+
+        return this.packageName;
     }
 
     /**

--- a/src/debugger/android/androidPlatform.ts
+++ b/src/debugger/android/androidPlatform.ts
@@ -51,13 +51,13 @@ export class AndroidPlatform implements IAppPlatform {
             () =>
                 Q(AndroidPlatform.RUN_ANDROID_FAILURE_PATTERNS)).process(runAndroidSpawn);
 
-        return output.finally(() =>
-            this.deviceHelper.getConnectedDevices().then(devices => {
+        return output.finally(() => {
+            return this.deviceHelper.getConnectedDevices().then(devices => {
                 this.devices = devices;
                 this.debugTarget = this.getTargetEmulator(runOptions, devices);
                 return this.getPackageName(runOptions.projectRoot).then(packageName =>
                     this.packageName = packageName);
-            }))
+            }}))
             .catch(reason => {
                 if (reason.message === AndroidPlatform.MULTIPLE_DEVICES_ERROR && this.devices.length > 1 && this.debugTarget) {
                     /* If it failed due to multiple devices, we'll apply this workaround to make it work anyways */
@@ -74,7 +74,6 @@ export class AndroidPlatform implements IAppPlatform {
         return this.deviceHelper.reloadAppInDebugMode(runOptions.projectRoot, this.packageName, this.debugTarget);
     }
 
-    // Package name is only used when we have multiple devices, or we go into debugging mode, so we initialize it lazily
     private getPackageName(projectRoot: string): Q.Promise<string> {
         return new Package(projectRoot).name().then(appName =>
                 new PackageNameResolver(appName).resolvePackageName(projectRoot));


### PR DESCRIPTION
This PR fixes a bug introduced when we merged the "Stop on Android Error" feature.