### PR TITLE
Error strings should print useful information about the command being run (command with args)

### DIFF
--- a/errorStrings/errorStrings.json
+++ b/errorStrings/errorStrings.json
@@ -1,6 +1,6 @@
 ﻿{
-    "CommandFailed": "Command {0} failed with error code {1}",
-    "CommandFailedWithErrorCode": "Error while executing command {0}",
+    "CommandFailed": "Error while executing command '{0}'",
+    "CommandFailedWithErrorCode": "Command '{0}' failed with error code {1}",
     "PackagerStartFailed": "Error while executing React Native Packager.",
     "IDeviceInstallerNotFound": "Unable to find ideviceinstaller. Please make sure to install Homebrew (http://brew.sh) and then 'brew install ideviceinstaller",
     "DeviceNotPluggedIn": "Unable to mount developer disk image.",

--- a/src/common/commandExecutor.ts
+++ b/src/common/commandExecutor.ts
@@ -155,12 +155,12 @@ export class CommandExecutor {
             () =>
                 Log.logCommandStatus(commandWithArgs, CommandStatus.End),
             reason =>
-                this.generateRejectionForCommand(command, reason));
+                this.generateRejectionForCommand(commandWithArgs, reason));
 
         return result;
     }
 
     private generateRejectionForCommand(command: string, reason: any): Q.Promise<void> {
-        return Q.reject<void>(ErrorHelper.getInternalError(InternalErrorCode.CommandFailed, command, reason));
+        return Q.reject<void>(ErrorHelper.getNestedError(reason, InternalErrorCode.CommandFailed, command));
     }
 }

--- a/src/common/node/childProcess.ts
+++ b/src/common/node/childProcess.ts
@@ -57,6 +57,7 @@ export class ChildProcess {
 
     public spawnWithExitHandler(command: string, args?: string[], options: ISpawnOptions = {}): ISpawnResult {
         let outcome = Q.defer<void>();
+        let commandWithArgs = command + " " + args.join(" ");
 
         let spawnedProcess = child_process.spawn(command, args, options);
         spawnedProcess.once("error", (error: any) => {
@@ -66,7 +67,7 @@ export class ChildProcess {
             if (code === 0) {
                 outcome.resolve(void 0);
             } else {
-                outcome.reject(ErrorHelper.getInternalError(InternalErrorCode.CommandFailed));
+                outcome.reject(ErrorHelper.getInternalError(InternalErrorCode.CommandFailedWithErrorCode, commandWithArgs, code));
             }
         });
 
@@ -80,9 +81,10 @@ export class ChildProcess {
 
     public spawn(command: string, args?: string[], options: ISpawnOptions = {}): ISpawnResult {
         let outcome = Q.defer<void>();
+        let commandWithArgs = command + " " + args.join(" ");
         let spawnedProcess = child_process.spawn(command, args, options);
         spawnedProcess.once("error", (error: any) => {
-            outcome.reject(ErrorHelper.getNestedError(error, InternalErrorCode.CommandFailed, command));
+            outcome.reject(ErrorHelper.getNestedError(error, InternalErrorCode.CommandFailed, commandWithArgs));
         });
 
         return {


### PR DESCRIPTION
(Porting over some must-fix items from refactor branch)