### PR TITLE
Upgraded all dev dependencies to their latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,21 +132,21 @@
         "ws": "1.0.1"
     },
     "devDependencies": {
-        "del": "2.2.0",
-        "gulp": "^3.9.0",
+        "del": "^2.2.0",
+        "gulp": "^3.9.1",
         "gulp-mocha": "^2.2.0",
-        "gulp-sourcemaps": "^1.5.2",
-        "gulp-tslint": "^3.3.1",
-        "gulp-typescript": "^2.8.0",
-        "gulp-util": "^3.0.5",
+        "gulp-sourcemaps": "^1.6.0",
+        "gulp-tslint": "^4.3.3",
+        "gulp-typescript": "^2.12.1",
+        "gulp-util": "^3.0.7",
         "mocha-teamcity-reporter": "^1.0.0",
         "run-sequence": "^1.1.5",
         "sinon": "^1.17.3",
-        "should": "^8.2.2",
+        "should": "^8.3.0",
         "through2": "^2.0.1",
-        "tslint": "^2.5.1",
-        "typescript": "^1.7.5",
-        "vsce": "1.0.0",
+        "tslint": "^3.6.0",
+        "typescript": "^1.8.9",
+        "vsce": "^1.3.0",
         "vscode": "^0.10.7"
     }
 }

--- a/src/common/error/errorHelper.ts
+++ b/src/common/error/errorHelper.ts
@@ -41,7 +41,7 @@ export class ErrorHelper {
          let result: string = <string> errorMessage;
          let args: string[] = ErrorHelper.getOptionalArgsArrayFromFunctionCall(arguments, 1);
          if (args) {
-            for (var i: number = 0; i < args.length; i++) {
+            for (let i: number = 0; i < args.length; i++) {
                 result = result.replace(new RegExp("\\{" + i + "\\}", "g"), args[i]);
             }
          }

--- a/src/common/ios/plistBuddy.ts
+++ b/src/common/ios/plistBuddy.ts
@@ -16,7 +16,7 @@ export class PlistBuddy {
 
     constructor({
         nodeChildProcess = new Node.ChildProcess(),
-        xcodeproj = new Xcodeproj()
+        xcodeproj = new Xcodeproj(),
     } = {}) {
         this.nodeChildProcess = nodeChildProcess;
         this.xcodeproj = xcodeproj;

--- a/src/common/ios/simulatorPlist.ts
+++ b/src/common/ios/simulatorPlist.ts
@@ -22,7 +22,7 @@ export class SimulatorPlist {
     constructor(projectRoot: string, {
         nodeFileSystem = new FileSystem(),
         plistBuddy = new PlistBuddy(),
-        nodeChildProcess = new ChildProcess()
+        nodeChildProcess = new ChildProcess(),
     } = {}) {
         this.projectRoot = projectRoot;
 
@@ -35,8 +35,8 @@ export class SimulatorPlist {
 
         return Q.all<any>([
             this.plistBuddy.getBundleId(this.projectRoot), // Find the name of the application
-            this.nodeChildProcess.exec("xcrun simctl getenv booted HOME").outcome]) // Find the path of the simulator we are running
-            .spread((bundleId: string, pathBuffer: Buffer) => {
+            this.nodeChildProcess.exec("xcrun simctl getenv booted HOME").outcome, // Find the path of the simulator we are running
+            ]).spread((bundleId: string, pathBuffer: Buffer) => {
                 const pathBefore = path.join(pathBuffer.toString().trim(), "Containers", "Data", "Application");
                 const pathAfter = path.join("Library", "Preferences", `${bundleId}.plist`);
 

--- a/src/common/ios/xcodeproj.ts
+++ b/src/common/ios/xcodeproj.ts
@@ -14,7 +14,7 @@ export class Xcodeproj {
     private nodeFileSystem: FileSystem;
 
     constructor({
-        nodeFileSystem = new FileSystem()
+        nodeFileSystem = new FileSystem(),
     } = {}) {
         this.nodeFileSystem = nodeFileSystem;
     }

--- a/src/common/node/childProcess.ts
+++ b/src/common/node/childProcess.ts
@@ -70,7 +70,7 @@ export class ChildProcess {
               stdin: spawnedProcess.stdin,
               stdout: spawnedProcess.stdout,
               stderr: spawnedProcess.stderr,
-              outcome: outcome.promise
+              outcome: outcome.promise,
        };
     }
 
@@ -96,7 +96,7 @@ export class ChildProcess {
               stdin: spawnedProcess.stdin,
               stdout: spawnedProcess.stdout,
               stderr: spawnedProcess.stderr,
-              outcome: outcome.promise
+              outcome: outcome.promise,
        };
     }
 }

--- a/src/common/telemetry.ts
+++ b/src/common/telemetry.ts
@@ -275,7 +275,7 @@ export module Telemetry {
                 let deferred: Q.Deferred<string> = Q.defer<string>();
                 let regKey = new winreg({
                                         hive: hive,
-                                        key: key
+                                        key: key,
                                 });
                 regKey.get(value, function(err: any, itemValue: winreg.RegistryItem) {
                     if (err) {

--- a/src/debugger/android/androidPlatform.ts
+++ b/src/debugger/android/androidPlatform.ts
@@ -27,7 +27,8 @@ export class AndroidPlatform implements IAppPlatform {
          + " configured device or emulator running. See https://facebook.github.io/react-native/docs/android-setup.html",
     "com.android.ddmlib.ShellCommandUnresponsiveException": "An Android shell command timed-out. Please retry the operation.",
     "Android project not found": "Android project not found.",
-    "error: more than one device/emulator": AndroidPlatform.MULTIPLE_DEVICES_ERROR };
+    "error: more than one device/emulator": AndroidPlatform.MULTIPLE_DEVICES_ERROR,
+    };
 
     private static RUN_ANDROID_SUCCESS_PATTERNS: string[] = ["BUILD SUCCESSFUL", "Starting the app", "Starting: Intent"];
 

--- a/src/debugger/appWorker.ts
+++ b/src/debugger/appWorker.ts
@@ -62,7 +62,7 @@ export class SandboxedAppWorker {
 
     constructor(sourcesStoragePath: string, debugAdapterPort: number, postReplyToApp: (message: any) => void, {
         nodeFileSystem = new FileSystem(),
-        scriptImporter = new ScriptImporter(sourcesStoragePath)
+        scriptImporter = new ScriptImporter(sourcesStoragePath),
     } = {}) {
         this.sourcesStoragePath = sourcesStoragePath;
         this.debugAdapterPort = debugAdapterPort;
@@ -100,7 +100,7 @@ export class SandboxedAppWorker {
             importScripts: (url: string) => this.importScripts(url), // Import script like using <script/>
             postMessage: (object: any) => this.gotResponseFromDebuggerWorker(object), // Post message back to the UI thread
             onmessage: null,
-            postMessageArgument: null
+            postMessageArgument: null,
         };
         this.sandbox.self = this.sandbox;
 
@@ -172,7 +172,7 @@ export class MultipleLifetimesAppWorker {
 
     constructor(sourcesStoragePath: string, debugAdapterPort: number, {
         sandboxedAppConstructor = (path: string, port: number, messageFunc: (message: any) => void) => new SandboxedAppWorker(path, port, messageFunc),
-        webSocketConstructor = (url: string) => new WebSocket(url)
+        webSocketConstructor = (url: string) => new WebSocket(url),
     } = {}) {
         this.sourcesStoragePath = sourcesStoragePath;
         this.debugAdapterPort = debugAdapterPort;

--- a/src/debugger/ios/compiler.ts
+++ b/src/debugger/ios/compiler.ts
@@ -30,7 +30,7 @@ export class Compiler {
                 "-project", path.join(this.projectRoot, "ios", projectFile),
                 "-scheme", projectName,
                 "-destination", "generic/platform=iOS", // Build for a generic iOS device
-                "-derivedDataPath", path.join(this.projectRoot, "ios", "build")
+                "-derivedDataPath", path.join(this.projectRoot, "ios", "build"),
             ];
         });
     }

--- a/src/debugger/ios/iOSPlatform.ts
+++ b/src/debugger/ios/iOSPlatform.ts
@@ -28,7 +28,8 @@ export class IOSPlatform implements IAppPlatform {
     // We should add the common iOS build/run erros we find to this list
     private static RUN_IOS_FAILURE_PATTERNS: PatternToFailure = {
         "No devices are booted": "Unable to launch iOS simulator. Try specifying a different target.",
-        "FBSOpenApplicationErrorDomain": "Unable to launch iOS simulator. Try specifying a different target." };
+        "FBSOpenApplicationErrorDomain": "Unable to launch iOS simulator. Try specifying a different target.",
+    };
 
     private static RUN_IOS_SUCCESS_PATTERNS = ["BUILD SUCCEEDED"];
 
@@ -74,7 +75,7 @@ export class IOSPlatform implements IAppPlatform {
         // Wait until the configuration file exists, and check to see if debugging is enabled
         return Q.all([
             iosDebugModeManager.getSimulatorJSDebuggingModeSetting(),
-            this.plistBuddy.getBundleId(launchArgs.projectRoot)
+            this.plistBuddy.getBundleId(launchArgs.projectRoot),
         ]).spread((debugModeSetting: string, bundleId: string) => {
             if (debugModeSetting !== IOSDebugModeManager.WEBSOCKET_EXECUTOR_NAME) {
                 // Debugging must still be enabled

--- a/src/debugger/nodeDebugWrapper.ts
+++ b/src/debugger/nodeDebugWrapper.ts
@@ -145,7 +145,7 @@ Telemetry.init("react-native-debug-adapter", version, true).then(() => {
         args.args = [
             args.platform,
             debugServerListeningPort.toString(),
-            args.target || "simulator"
+            args.target || "simulator",
         ];
 
         if (!isNullOrUndefined(args.logCatArguments)) { // We add the parameter if it's defined (adapter crashes otherwise)

--- a/src/extension/commandPaletteHandler.ts
+++ b/src/extension/commandPaletteHandler.ts
@@ -55,7 +55,7 @@ export class CommandPaletteHandler {
 
                 return Q.all<any>([
                     pkg.name().then((appName) => new PackageNameResolver(appName).resolvePackageName(this.workspaceRoot)),
-                    deviceHelper.getConnectedDevices()
+                    deviceHelper.getConnectedDevices(),
                 ]).spread<any>((packagName: string, devices: IDevice[]) => {
                     if (devices.length > 1) {
                         let result = Q<void>(void 0);

--- a/src/extension/intellisenseHelper.ts
+++ b/src/extension/intellisenseHelper.ts
@@ -197,7 +197,7 @@ export class IntellisenseHelper {
             .then((installed: boolean) => {
                 let installProps: IInstallProps = {
                     installed: installed,
-                    version: ""
+                    version: "",
                 };
 
                 if (installed === true) {

--- a/src/test/common/extensionMessaging.test.ts
+++ b/src/test/common/extensionMessaging.test.ts
@@ -5,7 +5,7 @@ import {HostPlatform} from "../../common/hostPlatform";
 
 import {
     ExtensionMessage,
-    ExtensionMessageSender
+    ExtensionMessageSender,
 } from "../../common/extensionMessaging";
 
 import * as assert from "assert";

--- a/src/test/common/ios/plistBuddy.test.ts
+++ b/src/test/common/ios/plistBuddy.test.ts
@@ -24,7 +24,7 @@ suite("plistBuddy", function() {
             mockedExecFunc.throws();
 
             const mockChildProcess: any = {
-                exec: mockedExecFunc
+                exec: mockedExecFunc,
             };
             const plistBuddy = new PlistBuddy({ nodeChildProcess: mockChildProcess });
 
@@ -48,7 +48,7 @@ suite("plistBuddy", function() {
             mockedExecFunc.throws();
 
             const mockChildProcess: any = {
-                exec: mockedExecFunc
+                exec: mockedExecFunc,
             };
             const plistBuddy = new PlistBuddy({ nodeChildProcess: mockChildProcess });
 
@@ -77,19 +77,19 @@ suite("plistBuddy", function() {
             mockedExecFunc.withArgs(printExecCall(true)).returns({outcome: Q.resolve(simulatorBundleId)});
             mockedExecFunc.withArgs(printExecCall(false)).returns({outcome: Q.resolve(deviceBundleId)});
             const mockChildProcess: any = {
-                exec: mockedExecFunc
+                exec: mockedExecFunc,
             };
 
             const mockedFindXcodeprojFile = sinon.stub();
             mockedFindXcodeprojFile.withArgs(projectRoot).returns(Q.resolve(appName + ".xcodeproj"));
             const mockXcodeproj: any = {
-                findXcodeprojFile: mockedFindXcodeprojFile
+                findXcodeprojFile: mockedFindXcodeprojFile,
             };
             const plistBuddy = new PlistBuddy({ nodeChildProcess: mockChildProcess, xcodeproj: mockXcodeproj });
 
             return Q.all([
                 plistBuddy.getBundleId(projectRoot, true),
-                plistBuddy.getBundleId(projectRoot, false)
+                plistBuddy.getBundleId(projectRoot, false),
             ]).spread((simulatorId, deviceId) => {
                 assert.equal(simulatorBundleId, simulatorId);
                 assert.equal(deviceBundleId, deviceId);

--- a/src/test/common/ios/simulatorPlist.test.ts
+++ b/src/test/common/ios/simulatorPlist.test.ts
@@ -25,7 +25,8 @@ suite("plistBuddy", function() {
             // The emulator has 3 apps
             const appIds = ["17F3AED1-5B1D-4F97-B419-D1F079D9DE2D",
                 "957660FD-3417-474E-B2AC-8AA0A05AD9A0",
-                "18319C8B-0583-4967-8023-15859A0BF0F3"];
+                "18319C8B-0583-4967-8023-15859A0BF0F3",
+            ];
 
             // readdir finds appIds
             const mockReadDir = sinon.stub();
@@ -42,7 +43,7 @@ suite("plistBuddy", function() {
 
             const mockFS: any = {
                 existsSync: mockExistsSync,
-                readDir: mockReadDir
+                readDir: mockReadDir,
             };
 
             // getBundleId returns bundleId
@@ -51,7 +52,7 @@ suite("plistBuddy", function() {
             bundleIdStub.returns(Q.reject("Incorrect project root"));
 
             const mockPlistBuddy: any = {
-                getBundleId: bundleIdStub
+                getBundleId: bundleIdStub,
             };
 
             // exec-ing the correct command returns the simulator home
@@ -59,13 +60,13 @@ suite("plistBuddy", function() {
             execStub.withArgs(findSimulatorHomeCommand).returns({ outcome: Q.resolve(findSimulatorHomeResult) });
             execStub.throws();
             const mockChildProcess: any = {
-                exec: execStub
+                exec: execStub,
             };
 
             const simulatorPlist = new SimulatorPlist(projectRoot, {
                 nodeFileSystem: mockFS,
                 plistBuddy: mockPlistBuddy,
-                nodeChildProcess: mockChildProcess
+                nodeChildProcess: mockChildProcess,
             });
 
             return simulatorPlist.findPlistFile().then((plistFile) => {

--- a/src/test/common/ios/xcodeproj.test.ts
+++ b/src/test/common/ios/xcodeproj.test.ts
@@ -19,7 +19,7 @@ suite("xcodeproj", function() {
                         throw new Error(`Expected ${extension} got ${ext}`);
                     }
                     return Q(testFiles);
-                }
+                },
             };
 
             const xcodeproj = new Xcodeproj({ nodeFileSystem: mockFileSystem });

--- a/src/test/debugger/appWorker.test.ts
+++ b/src/test/debugger/appWorker.test.ts
@@ -25,16 +25,16 @@ suite("appWorker", function() {
 
             setup(function() {
                 const nodeFileSystemMock: any = {
-                    readFile: readFileStub
+                    readFile: readFileStub,
                 };
 
                 const scriptImporterMock: any = {
-                    downloadAppScript: downloadAppScriptStub
+                    downloadAppScript: downloadAppScriptStub,
                 };
 
                 sandboxedWorker = new AppWorker.SandboxedAppWorker(sourcesStoragePath, debugAdapterPort, postReplyFunction, {
                     nodeFileSystem: nodeFileSystemMock,
-                    scriptImporter: scriptImporterMock
+                    scriptImporter: scriptImporterMock,
                 });
             });
 
@@ -69,7 +69,7 @@ suite("appWorker", function() {
                 downloadAppScriptStub.withArgs(scriptImportPath, debugAdapterPort).returns(scriptImportDeferred.promise.then(() => {
                     return {
                         contents: testScriptContents,
-                        filepath: scriptImportPath
+                        filepath: scriptImportPath,
                     };
                 }));
 
@@ -128,7 +128,7 @@ suite("appWorker", function() {
 
                 multipleLifetimesWorker = new AppWorker.MultipleLifetimesAppWorker(sourcesStoragePath, debugAdapterPort, {
                     sandboxedAppConstructor: sandboxedAppConstructor,
-                    webSocketConstructor: webSocketConstructor
+                    webSocketConstructor: webSocketConstructor,
                 });
             });
 

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -11,7 +11,7 @@ let mochaOptions: any = {
     ui: "tdd",
     useColors: true,
     invert: true,
-    grep: "debuggerContext" // Do not run tests intended for the debuggerContext
+    grep: "debuggerContext", // Do not run tests intended for the debuggerContext
 };
 
 // Look for the env variable to decide wheter to use the TeamCity reporter or not

--- a/tslint.json
+++ b/tslint.json
@@ -50,7 +50,6 @@
         "no-eval": true,
         "no-inferrable-types": false,
         "no-internal-module": false,
-        "no-keyword-named-variables": true,
         "no-require-imports": false,
         "no-shadowed-variable": true,
         "no-string-literal": true,
@@ -62,7 +61,7 @@
         "no-use-before-declare": true,
         "no-var-keyword": true,
         "no-var-requires": true,
-        "object-literal-sort-keys": true,
+        "object-literal-sort-keys": false,
         "one-line": [
             true,
             "check-open-brace",


### PR DESCRIPTION
Turned off object-literal-sort-keys because it asks to change:
{ message: ..., args: ... } to { args: ..., message: ... }
no-keyword-named-variables doesn't seem to exist any more
added the trailing commas because we had the option turned on, but we used an old tlisnt version that didn't run that check.
Didn't update vscode because it breaks stuff (We should create a small task to update that one).