### PR TITLE
Now we can debug mocha tests from VS Code, and filter test with gulp test --pattern <pattern>

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -108,8 +108,9 @@
             "args": [
                 "--ui",
                 "tdd",
-                // "--grep", "androidPlatform",
-                "out/test/debugger/**/*.test.js"
+                // "--grep", "patternToFilterTestsBy",
+                "out/test/debugger/**/*.test.js",
+                "out/test/common/**/*.test.js"
             ],
             "cwd": "${workspaceRoot}",
             "runtimeExecutable": null,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,9 +18,13 @@
             "type": "node",
             "request": "launch",
             "program": "${workspaceRoot}/out/debugger/nodeDebugWrapper.js",
-            "runtimeArgs": ["--harmony"],
+            "runtimeArgs": [
+                "--harmony"
+            ],
             "stopOnEntry": false,
-            "args": [ "--server=4712" ], // Use "debugServer": "4712" on launch.json of the instance to debug
+            "args": [
+                "--server=4712"
+            ], // Use "debugServer": "4712" on launch.json of the instance to debug
             "sourceMaps": true,
             "outDir": "${workspaceRoot}/out",
             "preLaunchTask": "build"
@@ -94,6 +98,26 @@
             "sourceMaps": true,
             "outDir": "${workspaceRoot}/out",
             "preLaunchTask": "build"
+        },
+        {
+            "name": "Run mocha",
+            "type": "node",
+            "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+            "stopOnEntry": false,
+            // Command line arguments passed to the program.
+            "args": [
+                "--ui",
+                "tdd",
+                // "--grep", "androidPlatform",
+                "out/test/debugger/**/*.test.js"
+            ],
+            "cwd": "${workspaceRoot}",
+            "runtimeExecutable": null,
+            "env": {
+                "NODE_ENV": "development"
+            },
+            "sourceMaps": true,
+            "outDir": "${workspaceRoot}/out"
         }
     ]
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -71,7 +71,6 @@ function readArgument(argumentName) {
 
 function test() {
     // Defaults
-    var pattern = "extensionContext";
     var invert = true;
 
     // Check if arguments were passed
@@ -79,6 +78,8 @@ function test() {
     if (pattern !== null) {
         invert = false;
         console.log("\nTesting cases that match pattern: " + pattern);
+    } else {
+        pattern = "extensionContext";
     }
 
     return gulp.src(['out/test/**/*.test.js', '!out/test/extension/**'])

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -61,15 +61,21 @@ gulp.task('tslint', function () {
         .pipe(tslint.report('verbose'));
 });
 
+function readArgument(argumentName) {
+    var parameterIndex = process.argv.indexOf("--" + argumentName);
+    return parameterIndex > -1 && (parameterIndex + 1) < process.argv.length
+        ? process.argv[parameterIndex + 1]
+        : null;
+}
+
 function test() {
     // Defaults
     var pattern = "extensionContext";
     var invert = true;
 
     // Check if arguments were passed
-    var patternIndex = process.argv.indexOf("--pattern");
-    if (patternIndex > -1 && (patternIndex + 1) < process.argv.length) {
-        pattern = process.argv[patternIndex + 1];
+    var pattern = readArgument("pattern");
+    if (pattern !== null) {
         invert = false;
         console.log("\nTesting cases that match pattern: " + pattern);
     }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -80,6 +80,7 @@ function test() {
         console.log("\nTesting cases that match pattern: " + pattern);
     } else {
         pattern = "extensionContext";
+        console.log("\nTesting cases that don't match pattern: " + pattern);
     }
 
     return gulp.src(['out/test/**/*.test.js', '!out/test/extension/**'])

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -62,9 +62,10 @@ gulp.task('tslint', function () {
 });
 
 function readArgument(argumentName) {
-    var parameterIndex = process.argv.indexOf("--" + argumentName);
-    return parameterIndex > -1 && (parameterIndex + 1) < process.argv.length
-        ? process.argv[parameterIndex + 1]
+    var argumentNameIndex = process.argv.indexOf("--" + argumentName);
+    var argumentValueIndex = argumentNameIndex + 1;
+    return argumentNameIndex > -1 && argumentValueIndex < process.argv.length
+        ? process.argv[argumentValueIndex]
         : null;
 }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -62,12 +62,24 @@ gulp.task('tslint', function () {
 });
 
 function test() {
+    // Defaults
+    var pattern = "extensionContext";
+    var invert = true;
+
+    // Check if arguments were passed
+    var patternIndex = process.argv.indexOf("--pattern");
+    if (patternIndex > -1 && (patternIndex + 1) < process.argv.length) {
+        pattern = process.argv[patternIndex + 1];
+        invert = false;
+        console.log("\nTesting cases that match pattern: " + pattern);
+    }
+
     return gulp.src(['out/test/**/*.test.js', '!out/test/extension/**'])
         .pipe(mocha({
             ui: 'tdd',
             useColors: true,
-            invert: true,
-            grep: "extensionContext" // Do not run tests intended for the extensionContext
+            invert: invert,
+            grep: pattern
         }));
 }
 

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
         "gulp-tslint": "^3.3.1",
         "gulp-typescript": "^2.8.0",
         "gulp-util": "^3.0.5",
+        "mocha": "^2.4.5",
         "mocha-teamcity-reporter": "^1.0.0",
         "run-sequence": "^1.1.5",
         "sinon": "^1.17.3",


### PR DESCRIPTION
* Added Run mocha as a new Debug target to debug the tests inside VS Cod
* Now we support a --pattern parameter in gulp test that can filter tests by case name