### PR TITLE
Added some methods needed for the run-android tests. Made other small fixes too.

### DIFF
--- a/src/common/android/packageNameResolver.ts
+++ b/src/common/android/packageNameResolver.ts
@@ -54,10 +54,10 @@ export class PackageNameResolver {
     }
 
     /**
-     * Gets the default package name, based on the applicaiton name.
+     * Gets the default package name, based on the application name.
      */
     private getDefaultPackageName(applicationName: string): string {
-        return PackageNameResolver.DefaultPackagePrefix + applicationName;
+        return PackageNameResolver.DefaultPackagePrefix + applicationName.toLowerCase();
     }
 
     /**

--- a/src/common/android/packageNameResolver.ts
+++ b/src/common/android/packageNameResolver.ts
@@ -57,7 +57,7 @@ export class PackageNameResolver {
      * Gets the default package name, based on the application name.
      */
     private getDefaultPackageName(applicationName: string): string {
-        return PackageNameResolver.DefaultPackagePrefix + applicationName.toLowerCase();
+        return (PackageNameResolver.DefaultPackagePrefix + applicationName).toLowerCase();
     }
 
     /**

--- a/src/common/hostPlatform.ts
+++ b/src/common/hostPlatform.ts
@@ -127,6 +127,7 @@ export class HostPlatform {
                     break;
                 default:
                     HostPlatform.platformInstance = new LinuxHostPlatform();
+                    break;
             }
         }
 

--- a/src/common/node/fileSystem.ts
+++ b/src/common/node/fileSystem.ts
@@ -154,6 +154,13 @@ export class FileSystem {
         });
     }
 
+
+    /**
+     * Delete 'dirPath' if it's an empty folder. If not fail.
+     *
+     * @param {dirPath} path to the folder
+     * @returns {void} Nothing
+     */
     public rmdir(dirPath: string): Q.Promise<void> {
         return Q.nfcall<void>(this.fs.rmdir, dirPath);
     }

--- a/src/common/node/fileSystem.ts
+++ b/src/common/node/fileSystem.ts
@@ -6,7 +6,7 @@ import * as path from "path";
 import * as Q from "q";
 
 export class FileSystem {
-    private fs = fs; // TODO: Remove this after mering with the PR that expects this as a constructor parameter
+    private fs = fs; // TODO: Remove this after merging with the PR that expects this as a constructor parameter
 
     public ensureDirectory(dir: string): Q.Promise<void> {
         return Q.nfcall(fs.stat, dir).then((stat: fs.Stats): void => {

--- a/src/common/node/fileSystem.ts
+++ b/src/common/node/fileSystem.ts
@@ -6,6 +6,7 @@ import * as path from "path";
 import * as Q from "q";
 
 export class FileSystem {
+    private fs = fs; // TODO: Remove this after mering with the PR that expects this as a constructor parameter
 
     public ensureDirectory(dir: string): Q.Promise<void> {
         return Q.nfcall(fs.stat, dir).then((stat: fs.Stats): void => {
@@ -136,7 +137,25 @@ export class FileSystem {
     }
 
     public mkDir(p: string): Q.Promise<void> {
-        return Q.nfcall<void>(fs.mkdir, p);
+        return Q.nfcall<void>(this.fs.mkdir, p);
+    }
+
+    public stat(path: string): Q.Promise<fs.Stats> {
+        return Q.nfcall<fs.Stats>(this.fs.stat, path);
+    }
+
+    public directoryExists(directoryPath: string): Q.Promise<boolean> {
+        return this.stat(directoryPath).then(stats => {
+            return stats.isDirectory();
+        }).catch(reason => {
+            return reason.code === "ENOENT"
+                ? false
+                : Q.reject<boolean>(reason);
+        });
+    }
+
+    public rmdir(dirPath: string): Q.Promise<void> {
+        return Q.nfcall<void>(this.fs.rmdir, dirPath);
     }
 
     /**

--- a/src/common/node/fileSystem.ts
+++ b/src/common/node/fileSystem.ts
@@ -144,8 +144,8 @@ export class FileSystem {
         return Q.nfcall<void>(this.fs.mkdir, p);
     }
 
-    public stat(path: string): Q.Promise<fs.Stats> {
-        return Q.nfcall<fs.Stats>(this.fs.stat, path);
+    public stat(path: string): Q.Promise<nodeFs.Stats> {
+        return Q.nfcall<nodeFs.Stats>(this.fs.stat, path);
     }
 
     public directoryExists(directoryPath: string): Q.Promise<boolean> {

--- a/src/common/node/promise.ts
+++ b/src/common/node/promise.ts
@@ -22,6 +22,17 @@ export class PromiseUtil {
         return this.retryAsyncIteration(operation, condition, maxRetries, 0, delay, failure);
     }
 
+    public reduce<T>(sources: T[]|Q.Promise<T[]>, generateAsyncOperation: (value: T) => Q.Promise<void>): Q.Promise<void> {
+        const promisedSources = <Q.Promise<T[]>>Q(sources);
+        return promisedSources.then(resolvedSources => {
+            return resolvedSources.reduce((previousReduction: Q.Promise<void>, newSource: T) => {
+                return previousReduction.then(() => {
+                    return generateAsyncOperation(newSource);
+                });
+            }, Q<void>(void 0));
+        });
+    }
+
     private retryAsyncIteration<T>(operation: () => Q.Promise<T>, condition: (result: T) => boolean | Q.Promise<boolean>, maxRetries: number, iteration: number, delay: number, failure: string): Q.Promise<T> {
         return operation()
             .then(result => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
         "sourceMap": true,
         "rootDir": "src",
         "noImplicitAny": true,
-        "removeComments": false
+        "removeComments": false,
+        "noFallthroughCasesInSwitch": true
     },
     "exclude": [
         "node_modules",

--- a/tslint.json
+++ b/tslint.json
@@ -54,7 +54,7 @@
         "no-require-imports": false,
         "no-shadowed-variable": true,
         "no-string-literal": true,
-        "no-switch-case-fall-through": true,
+        "no-switch-case-fall-through": false,
         "no-trailing-whitespace": true,
         "no-unreachable": true,
         "no-unused-expression": true,


### PR DESCRIPTION
* When creating a project with react-native init, it converts the name to lower case. We are changing getDefaultPackageName to match that behavior.
* Now we use the noFallthroughCasesInSwitch typescript option instead of the tslint option no-switch-case-fall-through that is going to be deprecated.
* Created some utility methods that are used by the run-android tests