### PR TITLE
Fixing an issue with 'this' in ios/deviceRunner

### DIFF
--- a/src/debugger/ios/deviceRunner.ts
+++ b/src/debugger/ios/deviceRunner.ts
@@ -51,7 +51,7 @@ export class DeviceRunner {
         const deferred2: Q.Deferred<net.Socket> = Q.defer<net.Socket>();
         const deferred3: Q.Deferred<net.Socket> = Q.defer<net.Socket>();
 
-        socket.on("data", function(data: any): void {
+        socket.on("data", (data: any): void => {
             data = data.toString();
             while (data[0] === "+") { data = data.substring(1); }
             // Acknowledge any packets sent our way
@@ -149,7 +149,7 @@ export class DeviceRunner {
     private startNativeDebugProxy(proxyPort: number): Q.Promise<void> {
         this.cleanup();
 
-        return this.mountDeveloperImage().then(function(): Q.Promise<any> {
+        return this.mountDeveloperImage().then((): Q.Promise<any> => {
             let result = this.childProcess.spawn("idevicedebugserverproxy",  [proxyPort.toString()]);
             result.outcome.done(() => {}, () => {}); // Q prints a warning if we don't call .done(). We ignore all outcome errors
             return result.startup.then(() => this.nativeDebuggerProxyInstance = result.spawnedProcess);
@@ -157,7 +157,7 @@ export class DeviceRunner {
     }
 
     private mountDeveloperImage(): Q.Promise<void> {
-        return this.getDiskImage().then(function(path: string): Q.Promise<void> {
+        return this.getDiskImage().then((path: string): Q.Promise<void> => {
             const imagemounter = this.childProcess.spawn("ideviceimagemounter", [path]).spawnedProcess;
             const deferred = Q.defer<void>();
             let stdout: string = "";

--- a/src/debugger/ios/deviceRunner.ts
+++ b/src/debugger/ios/deviceRunner.ts
@@ -20,7 +20,7 @@ export class DeviceRunner {
 
     public run(): Q.Promise<void> {
         const proxyPort = 9999;
-        const appLaunchStepTimeout = 5000;
+        const appLaunchStepTimeout = 10000;
         return new PlistBuddy().getBundleId(this.projectRoot, /*simulator=*/false)
             .then((bundleId: string) => this.getPathOnDevice(bundleId))
             .then((path: string) =>
@@ -49,7 +49,6 @@ export class DeviceRunner {
 
         const deferred1: Q.Deferred<net.Socket> = Q.defer<net.Socket>();
         const deferred2: Q.Deferred<net.Socket> = Q.defer<net.Socket>();
-        const deferred3: Q.Deferred<net.Socket> = Q.defer<net.Socket>();
 
         socket.on("data", (data: any): void => {
             data = data.toString();
@@ -76,16 +75,11 @@ export class DeviceRunner {
                     }
                 } else if (data[1] === "O") {
                     // STDOUT was written to, and the rest of the input until reaching a "#" is a hex-encoded string of that output
-                    if (initState === 3) {
-                        deferred3.resolve(socket);
-                        initState++;
-                    }
                 } else if (data[1] === "E") {
                     // An error has occurred, with error code given by data[2-3]: parseInt(data.substring(2, 4), 16)
                     const error = new Error("Unable to launch application.");
                     deferred1.reject(error);
                     deferred2.reject(error);
-                    deferred3.reject(error);
                 }
             }
         });
@@ -94,13 +88,11 @@ export class DeviceRunner {
             const error = new Error("Unable to launch application.");
             deferred1.reject(error);
             deferred2.reject(error);
-            deferred3.reject(error);
         });
 
         socket.on("error", function(err: Error): void {
             deferred1.reject(err);
             deferred2.reject(err);
-            deferred3.reject(err);
         });
 
         socket.connect(portNumber, "localhost", () => {
@@ -122,15 +114,12 @@ export class DeviceRunner {
                 deferred2.reject(new Error("Timeout launching application. Is the device locked?"));
             }, appLaunchStepTimeout);
             return deferred2.promise;
-        }).then((sock: net.Socket): Q.Promise<net.Socket> => {
+        }).then((sock: net.Socket): void => {
             // Continue execution; actually start the app running.
             const cmd: string = this.makeGdbCommand("c");
             initState++;
             sock.write(cmd);
-            setTimeout(function(): void {
-                deferred3.reject(new Error("Timeout launching application. Is the device locked?"));
-            }, appLaunchStepTimeout);
-            return deferred3.promise;
+            return;
         }).then(() => packagePath);
     }
 

--- a/src/test/debugger/ios/deviceRunner.test.ts
+++ b/src/test/debugger/ios/deviceRunner.test.ts
@@ -150,14 +150,7 @@ suite("deviceRunner", function() {
                             dataString.should.equal(expectedResponse);
                             mockDebuggerProxy.protocolState++;
                             client.write("+");
-                            client.write("$OK#9A");
-                            break;
-                        case 4:
-                            expectedResponse = "$c#63";
-                            dataString.should.equal(expectedResponse);
-                            mockDebuggerProxy.protocolState++;
-                            client.write("+");
-                            client.write("$E23#AA"); // Report an error
+                            client.write("$E23#AA");
                             client.end();
                             break;
                         default:

--- a/src/test/resources/processExecution/simulator.ts
+++ b/src/test/resources/processExecution/simulator.ts
@@ -76,7 +76,7 @@ export class Simulator {
 
         /* We call spawnWaitUntilFinished to fill the ISpawnResult object appropiatedly. The command
            and the arguments don't affect that object, so we just pass an empty command and parameters */
-        return new ChildProcess({ childProcess: fakeChildProcessModule }).spawnWaitUntilFinished("", []);
+        return new ChildProcess({ childProcess: fakeChildProcessModule }).spawn("", []);
     }
 
     public simulate(recording: Recording): Q.Promise<void> {


### PR DESCRIPTION
Fixes #204 

When we changed to using a member variable childProcess we didn't account for `function() {}` style functions changing `this`. With this PR I convert relevant functions to `() => {}` style functions which preserve `this`.