### PR TITLE
Updated gulpfile so 'gulp test' will fail on errors

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,15 +46,18 @@ function readArgument(argumentName) {
 // TODO: The file property should point to the generated source (this implementation adds an extra folder to the path)
 // We should also make sure that we always generate urls in all the path properties (We shouldn't have \\s. This seems to
 // be an issue on Windows platforms)
-gulp.task('build', ["check-imports", "check-copyright"], function () {
+gulp.task('build', ["check-imports", "check-copyright"], function (callback) {
     var tsProject = ts.createProject('tsconfig.json');
     var isProd = options.env === 'production';
     var preprocessorContext = isProd ? { PROD: true } : { DEBUG: true };
     log(`Building with preprocessor context: ${JSON.stringify(preprocessorContext)}`);
     return tsProject.src()
-        .pipe(preprocess({context: preprocessorContext})) //To set environment variables in-line
+        .pipe(preprocess({ context: preprocessorContext })) //To set environment variables in-line
         .pipe(sourcemaps.init())
         .pipe(ts(tsProject))
+        .on('error', function (e) {
+            callback(e);
+        })
         .pipe(sourcemaps.write('.', {
             includeContent: false,
             sourceRoot: function (file) {

--- a/src/test/resources/fakeExtensionMessageSender.ts
+++ b/src/test/resources/fakeExtensionMessageSender.ts
@@ -4,16 +4,16 @@
 import * as Q from "q";
 
 import * as extensionMessaging from "../../common/extensionMessaging";
+import {IInterProcessMessageSender} from "../../common/interProcessMessageSender";
 
 type ExtensionMessage = extensionMessaging.ExtensionMessage;
-export type IExtensionMessageSender = extensionMessaging.IExtensionMessageSender;
 
 export interface IMessageSent {
     message: ExtensionMessage;
     args?: any[];
 }
 
-export class FakeExtensionMessageSender implements IExtensionMessageSender {
+export class FakeExtensionMessageSender implements IInterProcessMessageSender {
     private messagesSent: IMessageSent[] = [];
 
     private messageResponse: Q.Promise<any> = Q.resolve<void>(void 0);


### PR DESCRIPTION
* Using @dlebu's code to fix this issue
* Tested it with both working and broken source and it seems to work for both cases, although it prints a full stack trace when there is an error