### PR TITLE
Fix React Native project detection

### DIFF
--- a/src/common/node/package.ts
+++ b/src/common/node/package.ts
@@ -13,7 +13,7 @@ interface IPackageDependencyDict {
 export interface IPackageInformation {
     name: string;
     version: string;
-    dependencies?: IPackageDependencyDict;
+    peerDependencies?: IPackageDependencyDict;
     main?: string;
     [key: string]: any;
 }
@@ -41,8 +41,8 @@ export class Package {
         return this.parseProperty("name");
     }
 
-    public dependencies(): Q.Promise<IPackageDependencyDict> {
-        return this.parseProperty("dependencies");
+    public peerDependencies(): Q.Promise<IPackageDependencyDict> {
+        return this.parseProperty("peerDependencies");
     }
 
     public version(): Q.Promise<string> {

--- a/src/common/reactNativeProjectHelper.ts
+++ b/src/common/reactNativeProjectHelper.ts
@@ -20,8 +20,8 @@ export class ReactNativeProjectHelper {
      */
     public isReactNativeProject(): Q.Promise<boolean> {
         let currentPackage = new Package(this.workspaceRoot);
-        return currentPackage.dependencies().then(dependencies => {
-            return !!(dependencies && dependencies["react-native"]);
+        return currentPackage.peerDependencies().then(peerDependencies => {
+            return !!(peerDependencies && peerDependencies["react-native"]);
         }).catch((err: Error) => {
             return Q.resolve(false);
         });


### PR DESCRIPTION
As of React Native 0.23.1, `react-native` is specified in `peerDependencies` which breaks current React Native project detection.
React Native change log: https://github.com/facebook/react-native/releases/tag/v0.23.1

Despite it breaks detection for older projects, I dumped idea of parsing `dependencies`, `devDependencies` and `peerDependencies` in order to look for `react-native` dep. What's your opinion here?