### PR TITLE
Fix error handling of not-installed ideviceinstaller when running on device

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ More information about debugging using VS Code can be found in this [guide](http
 
 #### Debugging on iOS device
 Debugging on iOS device would require following manual steps.
+* You need to install [ideviceinstaller](https://github.com/libimobiledevice/ideviceinstaller) `brew install ideviceinstaller`
 * In your launch.json file, set target to "device"
 * Change the `jsCodeLocation` IP in your app using the steps detailed [here](https://facebook.github.io/react-native/docs/running-on-device-ios.html#accessing-development-server-from-device).
 * Choose **Debug iOS** configuration from the Configuration dropdown and press F5.

--- a/src/debugger/ios/deviceDeployer.ts
+++ b/src/debugger/ios/deviceDeployer.ts
@@ -23,7 +23,7 @@ export class DeviceDeployer {
                 "Build", "Products", "Debug-iphoneos", `${projectName}.app`);
             return new CommandExecutor(this.projectRoot)
                 .spawn("ideviceinstaller", ["-i", pathToCompiledApp]).catch((err) => {
-                    if ((<any>err).errorCode === 101 && (<any>err).innerError.code === "ENOENT") {
+                    if ((<any>err).errorCode === InternalErrorCode.CommandFailed && (<any>err).innerError.code === "ENOENT") {
                         throw ErrorHelper.getNestedError(err, InternalErrorCode.IDeviceInstallerNotFound);
                     }
                     throw err;

--- a/src/debugger/ios/deviceDeployer.ts
+++ b/src/debugger/ios/deviceDeployer.ts
@@ -23,7 +23,7 @@ export class DeviceDeployer {
                 "Build", "Products", "Debug-iphoneos", `${projectName}.app`);
             return new CommandExecutor(this.projectRoot)
                 .spawn("ideviceinstaller", ["-i", pathToCompiledApp]).catch((err) => {
-                    if ((<any>err).code === "ENOENT") {
+                    if ((<any>err).errorCode === 101 && (<any>err).innerError.code === "ENOENT") {
                         throw ErrorHelper.getNestedError(err, InternalErrorCode.IDeviceInstallerNotFound);
                     }
                     throw err;


### PR DESCRIPTION
As discussed in #211 this PR fixes the error handling when `ideviceinstaller` is not installed and the app should be launched on target `device`

fixes #211 