### PR TITLE
Support opening vscode in file at line from react native

### DIFF
--- a/scripts/atom
+++ b/scripts/atom
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# This script is called 'atom' to surpass the react-native
+# editor selection. It has nothing to do with the atom editor.
+# It can be safetly removed when the PR to support vscode in
+# react native gets accepted:
+# https://github.com/facebook/react-native/pull/7757
+#
+# Usage:
+# ../path/atom filename:filenumber
+
+# Unix
+if [[ -z "$1" ]] ; then
+    echo "Missing filename."
+    exit 1
+fi
+
+parent_path=$( cd "$(dirname "${BASH_SOURCE}")" ; pwd -P )
+node "$parent_path/../out/extension/openFileAtLocation.js" "$1"

--- a/scripts/atom.cmd
+++ b/scripts/atom.cmd
@@ -1,0 +1,17 @@
+:: This script is called 'atom' to surpass the react-native
+:: editor selection. It has nothing to do with the atom editor.
+:: It can be safetly removed when the PR to support vscode in
+:: react native gets accepted:
+:: https://github.com/facebook/react-native/pull/7757
+::
+:: Usage:
+:: ../path/atom.cmd filename:filenumber
+
+:: Windows
+@echo off
+
+IF [%1] == [] (
+   echo "Missing filename."
+   exit 1
+)
+node "%~dp0..\out\extension\openFileAtLocation.js" "%1"

--- a/src/common/error/internalErrorCode.ts
+++ b/src/common/error/internalErrorCode.ts
@@ -43,7 +43,8 @@ export enum InternalErrorCode {
         DebuggingFailed = 706,
         RNTempFolderDeletionFailed = 707,
         DebuggingFailedInNodeWrapper = 708,
-        PlatformNotSupported = 708,
+        PlatformNotSupported = 709,
+        WorkspaceNotFound = 710,
 
         // Activation errors
         CouldNotFindLocationOfNodeDebugger = 801,

--- a/src/common/extensionMessaging.ts
+++ b/src/common/extensionMessaging.ts
@@ -16,6 +16,7 @@ export enum ExtensionMessage {
     STOP_MONITORING_LOGCAT,
     GET_PACKAGER_PORT,
     SEND_TELEMETRY,
+    OPEN_FILE_AT_LOCATION,
 }
 
 export interface MessageWithArguments {

--- a/src/common/packager.ts
+++ b/src/common/packager.ts
@@ -55,13 +55,16 @@ export class Packager {
                     return this.monkeyPatchOpnForRNPackager()
                         .then(() => {
                             let args = ["--port", port.toString()];
-                            let childEnvForDebugging = Object.assign({}, process.env, { REACT_DEBUGGER: "echo A debugger is not needed: " });
+                            let reactEnv = Object.assign({}, process.env, {
+                                REACT_DEBUGGER: "echo A debugger is not needed: ",
+                                REACT_EDITOR: this.openFileAtLocationCommand(),
+                            });
 
                             Log.logMessage("Starting Packager");
                             // The packager will continue running while we debug the application, so we can"t
                             // wait for this command to finish
 
-                            let spawnOptions = { env: childEnvForDebugging };
+                            let spawnOptions = { env: reactEnv };
 
                             const packagerSpawnResult = new CommandExecutor(this.projectPath).spawnReactPackager(args, spawnOptions);
                             this.packagerProcess = packagerSpawnResult.spawnedProcess;
@@ -181,5 +184,9 @@ export class Packager {
             this.port = null;
             return Q.resolve<void>(void 0);
         });
+    }
+
+    private openFileAtLocationCommand(): string {
+        return path.join(__dirname, "..", "..", "scripts", "atom");
     }
 }

--- a/src/common/remoteExtension.ts
+++ b/src/common/remoteExtension.ts
@@ -35,6 +35,10 @@ export class RemoteExtension {
             [extensionId, extensionVersion, appInsightsKey, eventName, properties, measures]);
     }
 
+    public openFileAtLocation(filename: string, lineNumber: number): Q.Promise<void> {
+        return this.interProcessMessageSender.sendMessage(ExtensionMessage.OPEN_FILE_AT_LOCATION, [filename, lineNumber]);
+    }
+
     public getPackagerPort(): Q.Promise<number> {
         return this.interProcessMessageSender.sendMessage(ExtensionMessage.GET_PACKAGER_PORT);
     }

--- a/src/extension/extensionServer.ts
+++ b/src/extension/extensionServer.ts
@@ -38,6 +38,7 @@ export class ExtensionServer implements vscode.Disposable {
         this.messageHandlerDictionary[em.ExtensionMessage.STOP_MONITORING_LOGCAT] = this.stopMonitoringLogCat;
         this.messageHandlerDictionary[em.ExtensionMessage.GET_PACKAGER_PORT] = this.getPackagerPort;
         this.messageHandlerDictionary[em.ExtensionMessage.SEND_TELEMETRY] = this.sendTelemetry;
+        this.messageHandlerDictionary[em.ExtensionMessage.OPEN_FILE_AT_LOCATION] = this.openFileAtLocation;
     }
 
     /**
@@ -121,6 +122,19 @@ export class ExtensionServer implements vscode.Disposable {
             .done();
 
         return Q.resolve<void>(void 0);
+    }
+
+    /**
+     * Message handler for OPEN_FILE_AT_LOCATION
+     */
+    private openFileAtLocation(filename: string, lineNumber: number): Q.Promise<void> {
+        return Q(vscode.workspace.openTextDocument(vscode.Uri.file(filename)).then(document => {
+            return vscode.window.showTextDocument(document).then(editor => {
+                let range = editor.document.lineAt(lineNumber - 1).range;
+                editor.selection = new vscode.Selection(range.start, range.end);
+                editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
+            });
+        }));
     }
 
     private stopMonitoringLogCat(): Q.Promise<void> {

--- a/src/extension/openFileAtLocation.ts
+++ b/src/extension/openFileAtLocation.ts
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+import {RemoteExtension} from "../common/remoteExtension";
+import {ReactNativeProjectHelper} from "../common/reactNativeProjectHelper";
+import {InternalErrorCode} from "../common/error/internalErrorCode";
+import {ErrorHelper} from "../common/error/errorHelper";
+import * as path from "path";
+import * as Q from "q";
+
+/* Usage:
+...path\openFileAtLocation.js filename:lineNumber
+...path\openFileAtLocation.js filename
+*/
+
+if (process.argv.length < 3) {
+    throw "Wrong number of parameters provided. Please refer to the usage of this script for proper use.";
+}
+
+const fullpath = process.argv[2];
+const dirname = path.normalize(path.dirname(fullpath));
+
+// In Windows this should make sure c:\ is always lowercase and in
+// Unix '/'.toLowerCase() = '/'
+const normalizedDirname = dirname.charAt(0).toLowerCase() + dirname.slice(1);
+const filenameAndNumber = path.basename(fullpath);
+const fileInfo = filenameAndNumber.split(":");
+const filename = path.join(normalizedDirname, fileInfo[0]);
+let lineNumber: number = 1;
+
+if (fileInfo.length >= 2) {
+    lineNumber = parseInt(fileInfo[1], 10);
+}
+
+getReactNativeWorkspaceForFile(filename).then(projectRootPath => {
+    const remoteExtension = RemoteExtension.atProjectRootPath(projectRootPath);
+    return remoteExtension.openFileAtLocation(filename, lineNumber);
+}).done(() => { }, (reason) => {
+    throw ErrorHelper.getNestedError(reason, InternalErrorCode.CommandFailed,
+        "Unable to communicate with VSCode. Please make sure it is open in the appropriate workspace.");
+});
+
+function getReactNativeWorkspaceForFile(file: string): Q.Promise<string> {
+    return getPathForRNParentWorkspace(path.dirname(file))
+        .catch((reason) => {
+            return Q.reject<string>(ErrorHelper.getNestedError(reason, InternalErrorCode.WorkspaceNotFound, `Error while looking at workspace for file: ${file}.`));
+        });
+}
+
+function getPathForRNParentWorkspace(dir: string): Q.Promise<string> {
+    const reactNativeProjectHelper = new ReactNativeProjectHelper(dir);
+    return reactNativeProjectHelper.isReactNativeProject().then(isRNProject => {
+        if (isRNProject) {
+            return dir;
+        }
+        if (dir === "" || dir === "." || dir === "/" || dir === path.dirname(dir)) {
+            return Q.reject<string>(ErrorHelper.getInternalError(InternalErrorCode.WorkspaceNotFound, "React Native project workspace not found."));
+        }
+        return getPathForRNParentWorkspace(path.dirname(dir));
+    });
+}


### PR DESCRIPTION
React native provides a `GUI` (in the running simulator or device) with the stack trace when it encounters an error. If you click on a file name in that interface it should open up the editor of your choice with the selected file at a given line number. Currently `react native` supports a list of editors. This PR adds `vscode` to that list.

This PR is intended to work with the current version of `react native`. When the react native repo merges this PR:
https://github.com/facebook/react-native/pull/7757