### PR TITLE
Avoid prompt to restart VSCode after configuring react-native typings where possible

### DIFF
--- a/src/extension/intellisenseHelper.ts
+++ b/src/extension/intellisenseHelper.ts
@@ -170,8 +170,7 @@ export class IntellisenseHelper {
      * in order to enable the Salsa intellisense.
      */
     public static enableSalsa(isRestartRequired: boolean): Q.Promise<boolean> {
-        if (!process.env.VSCODE_TSJS) {
-
+        if (!IntellisenseHelper.isSalsaSupported() && !process.env.VSCODE_TSJS) {
             return Q({})
                 .then(() => HostPlatform.setEnvironmentVariable("VSCODE_TSJS", "1"))
                 .then(() => { return true; });


### PR DESCRIPTION
When intellisense is setup it checks if VSCode's installed version supports salsa. If it's not then it shows a prompt to restart VSCode so appropriate configurations can be made. This check was done in all steps of the setup except for the one where salsa was enabled.