### PR TITLE
Use vscode API to read configurations

### DIFF
--- a/src/common/configurationReader.ts
+++ b/src/common/configurationReader.ts
@@ -5,11 +5,45 @@ import {InternalErrorCode} from "./error/internalErrorCode";
 import {ErrorHelper} from "./error/errorHelper";
 
 export class ConfigurationReader {
+    public static readString(value: any): string {
+        if (this.isString(value)) {
+            return value;
+        } else {
+            throw ErrorHelper.getInternalError(InternalErrorCode.ExpectedStringValue, value);
+        }
+    }
+
+    public static readBoolean(value: any): boolean {
+        if (this.isBoolean(value)) {
+            return value;
+        } else if (value === "true" || value === "false") {
+            return value === "true";
+        } else {
+            throw ErrorHelper.getInternalError(InternalErrorCode.ExpectedBooleanValue, value);
+        }
+    }
+
+    public static readArray(value: any): Array<any> {
+        if (this.isArray(value)) {
+            return value;
+        } else {
+            throw ErrorHelper.getInternalError(InternalErrorCode.ExpectedArrayValue, value);
+        }
+    }
+
+    public static readObject(value: any): Object {
+        if (this.isObject(value)) {
+            return value;
+        } else {
+            throw ErrorHelper.getInternalError(InternalErrorCode.ExpectedObjectValue, value);
+        }
+    }
+
     /* We try to read an integer. It can be either an integer, or a string that can be parsed as an integer */
     public static readInt(value: any): number {
         if (this.isInt(value)) {
             return value;
-        } else if (typeof value === "string") {
+        } else if (this.isString(value)) {
             return parseInt(value, 10);
         } else {
             throw ErrorHelper.getInternalError(InternalErrorCode.ExpectedIntegerValue, value);
@@ -20,13 +54,29 @@ export class ConfigurationReader {
       If the value is provided but it can't be parsed we'll throw an exception so the user knows that we didn't understand
       the value that was provided */
     public static readIntWithDefaultSync(value: any, defaultValue: number): number {
-            return value ? this.readInt(value) : defaultValue;
+        return value ? this.readInt(value) : defaultValue;
     }
 
     public static readIntWithDefaultAsync(value: any, defaultValuePromise: Q.Promise<number>): Q.Promise<number> {
         return defaultValuePromise.then(defaultValue => {
             return this.readIntWithDefaultSync(value, defaultValue);
         });
+    }
+
+    private static isArray(value: any): boolean {
+        return Array.isArray(value);
+    }
+
+    private static isObject(value: any): boolean {
+        return typeof value === "object" || !ConfigurationReader.isArray(value);
+    }
+
+    private static isString(value: any): boolean {
+        return typeof value === "string";
+    }
+
+    private static isBoolean(value: any): boolean {
+        return typeof value === "boolean";
     }
 
     private static isInt(value: any): boolean {

--- a/src/common/error/internalErrorCode.ts
+++ b/src/common/error/internalErrorCode.ts
@@ -51,6 +51,10 @@ export enum InternalErrorCode {
 
         // Validating user input errors
         ExpectedIntegerValue = 1001,
+        ExpectedStringValue = 1002,
+        ExpectedBooleanValue = 1003,
+        ExpectedArrayValue = 1004,
+        ExpectedObjectValue = 1005,
 
         // Inter Process Communication errors
         ErrorWhileProcessingMessageInIPMSServer = 901,


### PR DESCRIPTION
Instead of reading the workspace configuration by parsing the `settings.json` file use the API provided by VSCode to do so. This lets the user have the same syntax as the one VSCode permits in their global settings file.

For legacy versions, whenever we need to update the user settings, the extension will show an information message telling the user to update the workspace `settings.json` manually.