### PR TITLE
Fix issue where typescript tsdk is in configuration but set to null

### DIFF
--- a/src/extension/settingsHelper.ts
+++ b/src/extension/settingsHelper.ts
@@ -35,7 +35,10 @@ export class SettingsHelper {
     public static getTypeScriptTsdk(): string {
         const workspaceConfiguration = vscode.workspace.getConfiguration();
         if (workspaceConfiguration.has("typescript.tsdk")) {
-            return ConfigurationReader.readString(workspaceConfiguration.get("typescript.tsdk"));
+            const tsdk = workspaceConfiguration.get("typescript.tsdk");
+            if (tsdk) {
+                return ConfigurationReader.readString(tsdk);
+            }
         }
         return null;
     }


### PR DESCRIPTION
When trying to get the Typescript Tsdk it could be in the configuration but set as null. This is an amend to https://github.com/Microsoft/vscode-react-native/pull/241 that didn't take that into account. 

Without this fix, the code does configure intellisense correctly but it shows an error message to the user telling him that intellisense was not configured. This every time it tries to configure it.