### PR TITLE
Downcase workspace path before hashing for socket pipe name

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Issue                                | Description
 Debugger doesn't stop at breakpoints | The debugger only works if the packager is started by VS Code. Stop the packager if it is already running outside VSCode.
 'adb: command not found'             | If you receive an error `adb: command not found`, you need to update your path variable to include the location of your *ADB* executable.The *ADB* executable file is located in a subdirectory along with your other Android SDK files.
 Targeting iPhone 6 doesn't work      | There is a known issue [#5850](https://github.com/facebook/react-native/issues/5850) while running an app targeting iPhone 6
+Can't comunicate with socket pipe    | If you have two workspaces open that only differ in casing, the extension will fail to comunicate effectively. (Linux only)
 
 [Known-Issues](https://github.com/Microsoft/vscode-react-native/issues?q=is%3Aissue+label%3Aknown-issues) provides a complete list of active and resolved issues.
 

--- a/src/common/extensionMessaging.ts
+++ b/src/common/extensionMessaging.ts
@@ -36,7 +36,8 @@ export class MessagingChannel {
            We create the pipe path hashing the user id + project root path so both client and server
            will generate the same path, yet it's unique for each vs code instance */
         const userID = HostPlatform.getUserID();
-        const uniqueSeed = `${userID}:${this.projectRootPath}`;
+        const normalizedRootPath = this.projectRootPath.toLowerCase();
+        const uniqueSeed = `${userID}:${normalizedRootPath}`;
         const hash = new Crypto().hash(uniqueSeed);
         return HostPlatform.getPipePath(`vscode-reactnative-${hash}`);
     }

--- a/src/extension/openFileAtLocation.ts
+++ b/src/extension/openFileAtLocation.ts
@@ -22,7 +22,7 @@ const dirname = path.normalize(path.dirname(fullpath));
 
 // In Windows this should make sure c:\ is always lowercase and in
 // Unix '/'.toLowerCase() = '/'
-const normalizedDirname = dirname.charAt(0).toLowerCase() + dirname.slice(1);
+const normalizedDirname = dirname.toLowerCase();
 const filenameAndNumber = path.basename(fullpath);
 const fileInfo = filenameAndNumber.split(":");
 const filename = path.join(normalizedDirname, fileInfo[0]);


### PR DESCRIPTION
In Windows and OS X file paths are case insensitive, but case preserving. Therefore we can refer to the same path with different case combinations. If we are hashing the workspace path, we need to make sure that it will always be the correct one, no matter what case it is.

NOTE. This fix leaves an issue exposed where, if you are in a linux machine, and you have two simultaneous workspace open that have the same path, but only differ on casing, then the socket will always talk to one of them.