### PR TITLE
User can attach to packager ran outside vscode to debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ Here is the list of common known issues you may experience while using the exten
 
 Issue                                | Description
 ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------
-Debugger doesn't stop at breakpoints | The debugger only works if the packager is started by VS Code. Stop the packager if it is already running outside VSCode.
 'adb: command not found'             | If you receive an error `adb: command not found`, you need to update your path variable to include the location of your *ADB* executable.The *ADB* executable file is located in a subdirectory along with your other Android SDK files.
 Targeting iPhone 6 doesn't work      | There is a known issue [#5850](https://github.com/facebook/react-native/issues/5850) while running an app targeting iPhone 6
 Can't comunicate with socket pipe    | If you have two workspaces open that only differ in casing, the extension will fail to comunicate effectively. (Linux only)

--- a/package.json
+++ b/package.json
@@ -81,13 +81,48 @@
                         "internalDebuggerPort": 9090,
                         "sourceMaps": true,
                         "outDir": "${workspaceRoot}/.vscode/.react"
+                    },
+                    {
+                        "name": "Attach to packager",
+                        "program": "${workspaceRoot}/.vscode/launchReactNative.js",
+                        "type": "reactnative",
+                        "request": "attach",
+                        "internalDebuggerPort": 9090,
+                        "sourceMaps": true,
+                        "outDir": "${workspaceRoot}/.vscode/.react"
                     }
                 ],
                 "configurationAttributes": {
+                    "attach": {
+                        "required": [
+                            "program"
+                        ],
+                        "properties": {
+                            "program": {
+                                "type": "string",
+                                "description": "The path to launchReactNative.js in the vscode folder"
+                            },
+                            "internalDebuggerPort": {
+                                "type": "number",
+                                "description": "A port to be used to enable automatic reloading of breakpoints when sourcemaps change.",
+                                "default": 9090
+                            },
+                            "sourceMaps": {
+                                "type": "boolean",
+                                "description": "Whether to use JavaScript source maps to map the generated bundled code back to its original sources",
+                                "default": false
+                            },
+                            "outDir": {
+                                "type": "string",
+                                "description": "The location of the generated JavaScript code (the bundle file). Normally this should be \"${workspaceRoot}/.vscode/.react\"",
+                                "default": null
+                            }
+                        }
+                    },
                     "launch": {
                         "required": [
-                            "platform",
-                            "program"
+                            "program",
+                            "platform"
                         ],
                         "properties": {
                             "platform": {

--- a/src/debugger/generalMobilePlatform.ts
+++ b/src/debugger/generalMobilePlatform.ts
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+import * as Q from "q";
+
+import {Log} from "../common/log/log";
+import {IRunOptions} from "../common/launchArgs";
+import {RemoteExtension} from "../common/remoteExtension";
+import {Packager} from "../common/packager";
+
+export class GeneralMobilePlatform {
+    protected projectPath: string;
+    protected remoteExtension: RemoteExtension;
+    protected platformName: string;
+
+    constructor(protected runOptions: IRunOptions, { remoteExtension = null } = {}) {
+        this.platformName = this.runOptions.platform;
+        this.projectPath = this.runOptions.projectRoot;
+        this.remoteExtension = (remoteExtension) ? remoteExtension : RemoteExtension.atProjectRootPath(runOptions.projectRoot);
+    }
+
+    public runApp(): Q.Promise<void> {
+        Log.logMessage("Conected to packager. You can now open your app in the simulator.");
+        return Q.resolve<void>(void 0);
+    }
+
+    public enableJSDebuggingMode(): Q.Promise<void> {
+        Log.logMessage("Debugger ready. Enable remote debugging in app.");
+        return Q.resolve<void>(void 0);
+    }
+
+    public startPackager(): Q.Promise<void> {
+        return this.remoteExtension.getPackagerPort().then(port => {
+            return Packager.isPackagerRunning(Packager.getHostForPort(port))
+            .then(isRunning => {
+                if (isRunning) {
+                    Log.logMessage("Attaching to running packager at port: " + port);
+                    return Q.resolve<void>(void 0);
+                }
+                return this.remoteExtension.startPackager();
+            });
+        });
+    }
+
+    public prewarmBundleCache(): Q.Promise<void> {
+        // generalMobilePlatform should do nothing here. Method should be overriden by children for specific behavior.
+        return Q.resolve<void>(void 0);
+    }
+}

--- a/src/debugger/nodeDebugAdapter.d.ts
+++ b/src/debugger/nodeDebugAdapter.d.ts
@@ -45,5 +45,8 @@ interface ILaunchRequestArgs {
 }
 
 interface IAttachRequestArgs {
+    internalDebuggerPort?: any;
     args: string[];
+    program: string;
+    platform: string;
 }

--- a/src/debugger/platformResolver.ts
+++ b/src/debugger/platformResolver.ts
@@ -4,21 +4,14 @@
 import {IRunOptions} from "../common/launchArgs";
 import {IOSPlatform} from "./ios/iOSPlatform";
 import {AndroidPlatform} from "../common/android/androidPlatform";
-
-/**
- * Contains all the mobile platform specific debugging operations.
- */
-export interface IAppPlatform {
-    runApp(): Q.Promise<void>;
-    enableJSDebuggingMode(): Q.Promise<void>;
-}
+import {GeneralMobilePlatform} from "./generalMobilePlatform";
 
 export class PlatformResolver {
 
     /**
      * Resolves the mobile application target platform.
      */
-    public resolveMobilePlatform(mobilePlatformString: string, runOptions: IRunOptions): IAppPlatform {
+    public resolveMobilePlatform(mobilePlatformString: string, runOptions: IRunOptions): GeneralMobilePlatform {
         switch (mobilePlatformString) {
             // We lazyly load the strategies, because some components might be
             // missing on some platforms (like XCode in Windows)
@@ -27,7 +20,7 @@ export class PlatformResolver {
             case "android":
                 return new AndroidPlatform(runOptions);
             default:
-                return null;
+                return new GeneralMobilePlatform(runOptions);
         }
     }
 }

--- a/src/typings/ws/ws.d.ts
+++ b/src/typings/ws/ws.d.ts
@@ -22,6 +22,7 @@ declare module "ws" {
         url: string;
         supports: any;
         upgradeReq: http.ServerRequest;
+        _closeMessage: string;
 
         CONNECTING: number;
         OPEN: number;


### PR DESCRIPTION
If user has started the debugger outside of VSCode, and wants to debug, the only way to go was using chrome dev tools. With this PR, the user can attach a VSCode debug session to a running packager.

One scenario when this is useful is when trying to debug native components in iOS using Xcode and have the need to debug the javascript code, where VSCode comes up handy.