### PR TITLE
React Native can also be a sub-dependency

### DIFF
--- a/src/common/reactNativeProjectHelper.ts
+++ b/src/common/reactNativeProjectHelper.ts
@@ -3,14 +3,35 @@
 
 import * as Q from "q";
 import * as semver from "semver";
-import {Package} from "./node/package";
+import {CommandExecutor} from "./commandExecutor";
 
 export class ReactNativeProjectHelper {
     private workspaceRoot: string;
-    private static REACT_NATIVE_NPM_LIB_NAME = "react-native";
 
     constructor(workspaceRoot: string) {
         this.workspaceRoot = workspaceRoot;
+    }
+
+    public getReactNativeVersion(): Q.Promise<string> {
+        let deferred = Q.defer<any>();
+
+        let outputStream = new CommandExecutor(this.workspaceRoot).spawnReactCommand("-v").stdout;
+        let output = "";
+
+        outputStream.on("data", (chunk: Buffer) => {
+          output += chunk.toString();
+        });
+
+        outputStream.on("end", () => {
+            const match = output.match(/react-native: ([\d\.]+)/);
+            deferred.resolve(match && match[1]);
+        });
+
+        outputStream.on("error", (err: Error) => {
+            deferred.reject(err);
+        });
+
+        return deferred.promise;
     }
 
     /**
@@ -19,22 +40,16 @@ export class ReactNativeProjectHelper {
      * {operation} - a function that performs the expected operation
      */
     public isReactNativeProject(): Q.Promise<boolean> {
-        let currentPackage = new Package(this.workspaceRoot);
-        return currentPackage.dependencies().then(dependencies => {
-            return !!(dependencies && dependencies["react-native"]);
-        }).catch((err: Error) => {
-            return Q.resolve(false);
-        });
+        return this.getReactNativeVersion().then(version => !!(version));
     }
 
     public validateReactNativeVersion(): Q.Promise<void> {
-        return new Package(this.workspaceRoot).dependencyPackage(ReactNativeProjectHelper.REACT_NATIVE_NPM_LIB_NAME).version()
-            .then(version => {
-                if (semver.gte(version, "0.19.0")) {
-                    return Q.resolve<void>(void 0);
-                } else {
-                    return Q.reject<void>(new RangeError(`Project version = ${version}`));
-                }
-            });
+        return this.getReactNativeVersion().then(version => {
+            if (semver.gte(version, "0.19.0")) {
+                return Q.resolve<void>(void 0);
+            } else {
+                return Q.reject<void>(new RangeError(`Project version = ${version}`));
+            }
+        });
     }
 }


### PR DESCRIPTION
Currently, for determining if a project is a react-native project, only the package.json is searched for the dependency 'react-native', Since it could be also a library which brings react-native, we have to check sub-dependencies too.

This PR introduces searching of sub-dependencies at a customizable level / depth. I added a test but was not sure how to implement, so it uses local directories. I didn't want to add it to this PR therefore.