### PR TITLE
Refactor nodeDebuggerAdapter wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
             {
                 "type": "reactnative",
                 "label": "React Native",
-                "program": "./out/debugger/nodeDebugWrapper.js",
+                "program": "./out/debugger/reactNativeDebugEntryPoint.js",
                 "runtime": "node",
                 "enableBrekapointsFor": {
                     "languageIds": [

--- a/src/common/log/logHelper.ts
+++ b/src/common/log/logHelper.ts
@@ -21,6 +21,7 @@ export class LogHelper {
     public static MESSAGE_TAG: string = "[vscode-react-native]";
     public static INTERNAL_TAG: string = "[Internal]";
     public static ERROR_TAG_FORMATSTRING: string = "[Error : %s] ";
+    public static ERROR_TAG: string = "[Error]";
     public static WARN_TAG: string = "[Warning]";
     private static ERROR_CODE_WIDTH: string = "0000";
     private static LOG_LEVEL_NAME: string = "RN_LOG_LEVEL";

--- a/src/debugger/launcher.ts
+++ b/src/debugger/launcher.ts
@@ -3,16 +3,13 @@
 
 import * as fs from "fs";
 import * as path from "path";
-import * as Q from "q";
+
 import {MultipleLifetimesAppWorker} from "./appWorker";
-import {Log} from "../common/log/log";
 import {ErrorHelper} from "../common/error/errorHelper";
 import {InternalErrorCode} from "../common/error/internalErrorCode";
 import {ScriptImporter} from "./scriptImporter";
-import {PlatformResolver} from "./platformResolver";
 import {TelemetryHelper} from "../common/telemetryHelper";
-import {TargetPlatformHelper} from "../common/targetPlatformHelper";
-import {IRunOptions} from "../common/launchArgs";
+import {Log} from "../common/log/log";
 import {RemoteExtension} from "../common/remoteExtension";
 import {EntryPointHandler, ProcessType} from "../common/entryPointHandler";
 
@@ -26,77 +23,29 @@ export class Launcher {
     }
 
     public launch(): void {
+        const debugAdapterPort = parseInt(process.argv[2], 10) || 9090;
         // Enable telemetry
         new EntryPointHandler(ProcessType.Debugee).runApp("react-native-debug-process", () => this.getAppVersion(),
             ErrorHelper.getInternalError(InternalErrorCode.DebuggingFailed), this.projectRootPath, () => {
                 return TelemetryHelper.generate("launch", (generator) => {
-                    const resolver = new PlatformResolver();
-                    return this.parseRunOptions().then(runOptions => {
-                        const mobilePlatform = resolver.resolveMobilePlatform(runOptions.platform, runOptions);
-                        if (!mobilePlatform) {
-                            throw new RangeError("The target platform could not be read. Did you forget to add it to the launch.json configuration arguments?");
-                        } else {
-                            const sourcesStoragePath = path.join(this.projectRootPath, ".vscode", ".react");
-                            return Q({})
-                                .then(() => {
-                                    generator.step("checkPlatformCompatibility");
-                                    TargetPlatformHelper.checkTargetPlatformSupport(runOptions.platform);
-                                    generator.step("startPackager");
-                                    return this.remoteExtension.startPackager();
-                                })
-                                .then(() => {
-                                    let scriptImporter = new ScriptImporter(runOptions.packagerPort, sourcesStoragePath);
-                                    return scriptImporter.downloadDebuggerWorker(sourcesStoragePath).then(() => {
-                                        Log.logMessage("Downloaded debuggerWorker.js (Logic to run the React Native app) from the Packager.");
-                                    });
-                                })
-                                // We've seen that if we don't prewarm the bundle cache, the app fails on the first attempt to connect to the debugger logic
-                                // and the user needs to Reload JS manually. We prewarm it to prevent that issue
-                                .then(() => {
-                                    generator.step("prewarmBundleCache");
-                                    Log.logMessage("Prewarming bundle cache. This may take a while ...");
-                                    return this.remoteExtension.prewarmBundleCache(runOptions.platform);
-                                })
-                                .then(() => {
-                                    generator.step("mobilePlatform.runApp");
-                                    Log.logMessage("Building and running application.");
-                                    return mobilePlatform.runApp();
-                                })
-                                .then(() => {
-                                    generator.step("Starting App Worker");
-                                    Log.logMessage("Starting debugger app worker.");
-                                    return new MultipleLifetimesAppWorker(runOptions.packagerPort, sourcesStoragePath, runOptions.debugAdapterPort).start();
-                                }) // Start the app worker
-                                .then(() => {
-                                    generator.step("mobilePlatform.enableJSDebuggingMode");
-                                    return mobilePlatform.enableJSDebuggingMode();
-                                }).then(() =>
-                                    Log.logMessage("Debugging session started successfully."));
-                        }
+                    const sourcesStoragePath = path.join(this.projectRootPath, ".vscode", ".react");
+                    return this.remoteExtension.getPackagerPort().then(packagerPort => {
+                        let scriptImporter = new ScriptImporter(packagerPort, sourcesStoragePath);
+                        return scriptImporter.downloadDebuggerWorker(sourcesStoragePath).then(() => {
+                            Log.logMessage("Downloaded debuggerWorker.js (Logic to run the React Native app) from the Packager.");
+                        }).then(() => {
+                            generator.step("Starting App Worker");
+                            Log.logMessage("Starting debugger app worker.");
+                            return new MultipleLifetimesAppWorker(packagerPort, sourcesStoragePath, debugAdapterPort).start();
+                        }).then(() =>
+                            Log.logMessage("Debugging session started successfully."));
                     });
                 });
-            });
+            }
+        );
     }
 
     private getAppVersion() {
         return JSON.parse(fs.readFileSync(path.join(__dirname, "..", "..", "package.json"), "utf-8")).version;
-    }
-
-    /**
-     * Parses the launch arguments set in the launch configuration.
-     */
-    private parseRunOptions(): Q.Promise<IRunOptions> {
-        // We expect our debugAdapter to pass in arguments as [platform, debugAdapterPort, iosRelativeProjectPath, target?, logCatArguments?];
-        return this.remoteExtension.getPackagerPort().then(packagerPort => {
-            return {
-                projectRoot: this.projectRootPath,
-                platform: process.argv[2].toLowerCase(),
-                debugAdapterPort: parseInt(process.argv[3], 10) || 9090,
-                target: process.argv[5],
-                packagerPort: packagerPort,
-                iosRelativeProjectPath: process.argv[4],
-                logCatArguments: process.argv[6],
-            };
-        });
     }
 }

--- a/src/debugger/nodeDebugAdapter.d.ts
+++ b/src/debugger/nodeDebugAdapter.d.ts
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+// These typings do not reflect the typings as intended to be used
+// but rather as they exist in truth, so we can reach into the internals
+// and access what we need.
+declare module VSCodeDebugAdapter {
+    class DebugSession {
+        public static run: Function;
+        public sendEvent(event: VSCodeDebugAdapter.InitializedEvent): void;
+        public start(input: any, output: any): void;
+        public launchRequest(response: any, args: any): void;
+        public attachRequest(response: any, args: any): void;
+        public disconnectRequest(response: any, args: any): void;
+    }
+    class InitializedEvent {
+        constructor();
+    }
+    class OutputEvent {
+        constructor(message: string, destination?: string);
+    }
+    class TerminatedEvent {
+        constructor();
+    }
+}
+
+declare class SourceMaps {
+    public _sourceToGeneratedMaps: {};
+    public _generatedToSourceMaps: {};
+    public _allSourceMaps: {};
+}
+
+declare class NodeDebugSession extends VSCodeDebugAdapter.DebugSession {
+    public _sourceMaps: SourceMaps;
+}
+
+interface ILaunchRequestArgs {
+    platform: string;
+    target?: string;
+    internalDebuggerPort?: any;
+    iosRelativeProjectPath?: string;
+    args: string[];
+    logCatArguments: any;
+    program: string;
+}
+
+interface IAttachRequestArgs {
+    args: string[];
+}

--- a/src/debugger/nodeDebugWrapper.ts
+++ b/src/debugger/nodeDebugWrapper.ts
@@ -1,194 +1,251 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
-import * as fs from "fs";
+import * as Q from "q";
 import * as path from "path";
 import * as http from "http";
 
 import {Telemetry} from "../common/telemetry";
 import {TelemetryHelper} from "../common/telemetryHelper";
 import {RemoteExtension} from "../common/remoteExtension";
-import {EntryPointHandler, ProcessType} from "../common/entryPointHandler";
-import {ErrorHelper} from "../common/error/errorHelper";
-import {InternalErrorCode} from "../common/error/internalErrorCode";
 import {IOSPlatform} from "./ios/iOSPlatform";
-import {ExtensionTelemetryReporter, NullTelemetryReporter, ReassignableTelemetryReporter} from "../common/telemetryReporters";
+import {PlatformResolver} from "./platformResolver";
+import {IRunOptions} from "../common/launchArgs";
+import {TargetPlatformHelper} from "../common/targetPlatformHelper";
+import {ExtensionTelemetryReporter, ReassignableTelemetryReporter} from "../common/telemetryReporters";
+import {NodeDebugAdapterLogger} from "../common/log/loggers";
+import {Log} from "../common/log/log";
 
-// These typings do not reflect the typings as intended to be used
-// but rather as they exist in truth, so we can reach into the internals
-// and access what we need.
-declare module VSCodeDebugAdapter {
-    class DebugSession {
-        public static run: Function;
-        public sendEvent(event: VSCodeDebugAdapter.InitializedEvent): void;
-        public start(input: any, output: any): void;
-        public launchRequest(response: any, args: any): void;
-        public disconnectRequest(response: any, args: any): void;
+export class NodeDebugWrapper {
+    private projectRootPath: string;
+    private remoteExtension: RemoteExtension;
+    private telemetryReporter: ReassignableTelemetryReporter;
+    private appName: string;
+    private version: string;
+    private mobilePlatformOptions: IRunOptions;
+
+    private vscodeDebugAdapterPackage: typeof VSCodeDebugAdapter;
+    private nodeDebugSession: typeof NodeDebugSession;
+    private originalLaunchRequest: (response: any, args: any) => void;
+
+    public constructor(appName: string, version: string, telemetryReporter: ReassignableTelemetryReporter, debugAdapter: typeof VSCodeDebugAdapter, debugSession: typeof NodeDebugSession) {
+        this.appName = appName;
+        this.version = version;
+        this.telemetryReporter = telemetryReporter;
+        this.vscodeDebugAdapterPackage = debugAdapter;
+        this.nodeDebugSession = debugSession;
+        this.originalLaunchRequest = this.nodeDebugSession.prototype.launchRequest;
     }
-    class InitializedEvent {
-        constructor();
+
+    /**
+     * Calls customize methods for all requests needed
+     */
+    public customizeNodeAdapterRequests(): void {
+        this.customizeLaunchRequest();
+        this.customizeAttachRequest();
+        this.customizeDisconnectRequest();
     }
-    class OutputEvent {
-        constructor(message: string, destination?: string);
-    }
-    class TerminatedEvent {
-        constructor();
-    }
-}
 
-declare class SourceMaps {
-    public _sourceToGeneratedMaps: {};
-    public _generatedToSourceMaps: {};
-    public _allSourceMaps: {};
-}
+    /**
+     * Intecept the "launchRequest" instance method of NodeDebugSession to interpret arguments.
+     * Launch should:
+     * - Run the packager if needed
+     * - Compile and run application
+     * - Prewarm bundle
+     */
+    private customizeLaunchRequest(): void {
+        const nodeDebugWrapper = this;
+        this.nodeDebugSession.prototype.launchRequest = function (request: any, args: ILaunchRequestArgs) {
+            nodeDebugWrapper.requestSetup(this, args);
+            nodeDebugWrapper.mobilePlatformOptions.target = args.target || "simulator";
+            nodeDebugWrapper.mobilePlatformOptions.iosRelativeProjectPath = !nodeDebugWrapper.isNullOrUndefined(args.iosRelativeProjectPath) ?
+                args.iosRelativeProjectPath :
+                IOSPlatform.DEFAULT_IOS_PROJECT_RELATIVE_PATH;
 
-declare class NodeDebugSession extends VSCodeDebugAdapter.DebugSession {
-    public _sourceMaps: SourceMaps;
-}
-
-interface ILaunchArgs {
-    platform: string;
-    target?: string;
-    internalDebuggerPort?: any;
-    iosRelativeProjectPath?: string;
-    args: string[];
-    logCatArguments: any;
-    program: string;
-}
-
-let version = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "..", "package.json"), "utf-8")).version;
-
-function bailOut(reason: string): void {
-    // Things have gone wrong in initialization: Report the error to telemetry and exit
-    TelemetryHelper.sendSimpleEvent(reason);
-    process.exit(1);
-}
-
-function parseLogCatArguments(userProvidedLogCatArguments: any) {
-    return Array.isArray(userProvidedLogCatArguments)
-        ? userProvidedLogCatArguments.join(" ") // If it's an array, we join the arguments
-        : userProvidedLogCatArguments; // If not, we leave it as-is
-}
-
-function isNullOrUndefined(value: any): boolean {
-    return typeof value === "undefined" || value === null;
-}
-
-let projectRootPath: string = null;
-
-// Enable telemetry
-const telemetryReporter = new ReassignableTelemetryReporter(new NullTelemetryReporter());
-const appName = "react-native-debug-adapter";
-new EntryPointHandler(ProcessType.Debugger).runApp(appName, () => version,
-    ErrorHelper.getInternalError(InternalErrorCode.DebuggingFailed), telemetryReporter, () => {
-        let nodeDebugFolder: string;
-        let vscodeDebugAdapterPackage: typeof VSCodeDebugAdapter;
-
-        // nodeDebugLocation.json is dynamically generated on extension activation.
-        // If it fails, we must not have been in a react native project
-        try {
-            /* tslint:disable:no-var-requires */
-            nodeDebugFolder = require("./nodeDebugLocation.json").nodeDebugPath;
-            vscodeDebugAdapterPackage = require(path.join(nodeDebugFolder, "node_modules", "vscode-debugadapter"));
-            /* tslint:enable:no-var-requires */
-        } catch (e) {
-            // Nothing we can do here: can't even communicate back because we don't know how to speak debug adapter
-            bailOut("cannotFindDebugAdapter");
-        }
-
-        // Temporarily dummy out the DebugSession.run function so we do not start the debug adapter until we are ready
-        const originalDebugSessionRun = vscodeDebugAdapterPackage.DebugSession.run;
-        vscodeDebugAdapterPackage.DebugSession.run = function() { };
-
-        let nodeDebug: { NodeDebugSession: typeof NodeDebugSession };
-
-        try {
-            /* tslint:disable:no-var-requires */
-            nodeDebug = require(path.join(nodeDebugFolder, "out", "node", "nodeDebug"));
-            /* tslint:enable:no-var-requires */
-        } catch (e) {
-            // Unable to find nodeDebug, but we can make our own communication channel now
-            const debugSession = new vscodeDebugAdapterPackage.DebugSession();
-            // Note: this will not work in the context of debugging the debug adapter and communicating over a socket,
-            // but in that case we have much better ways to investigate errors.
-            debugSession.start(process.stdin, process.stdout);
-            debugSession.sendEvent(new vscodeDebugAdapterPackage.OutputEvent("Unable to start debug adapter: " + e.toString(), "stderr"));
-            debugSession.sendEvent(new vscodeDebugAdapterPackage.TerminatedEvent());
-
-            bailOut("cannotFindNodeDebugAdapter");
-        }
-
-        vscodeDebugAdapterPackage.DebugSession.run = originalDebugSessionRun;
-
-        // Intecept the "launchRequest" instance method of NodeDebugSession to interpret arguments
-        const originalNodeDebugSessionLaunchRequest = nodeDebug.NodeDebugSession.prototype.launchRequest;
-        nodeDebug.NodeDebugSession.prototype.launchRequest = function(request: any, args: ILaunchArgs) {
-            projectRootPath = path.resolve(args.program, "../..");
-            telemetryReporter.reassignTo(new ExtensionTelemetryReporter( // We start to send telemetry
-                appName, version, Telemetry.APPINSIGHTS_INSTRUMENTATIONKEY, projectRootPath));
-
-            // Create a server waiting for messages to re-initialize the debug session;
-            const reinitializeServer = http.createServer((req, res) => {
-                res.statusCode = 404;
-                if (req.url === "/refreshBreakpoints") {
-                    res.statusCode = 200;
-                    if (this) {
-                        const sourceMaps = this._sourceMaps;
-                        if (sourceMaps) {
-                            // Flush any cached source maps
-                            sourceMaps._allSourceMaps = {};
-                            sourceMaps._generatedToSourceMaps = {};
-                            sourceMaps._sourceToGeneratedMaps = {};
-                        }
-                        // Send an "initialized" event to trigger breakpoints to be re-sent
-                        this.sendEvent(new vscodeDebugAdapterPackage.InitializedEvent());
-                    }
-                }
-                res.end();
-            });
-            const debugServerListeningPort = parseInt(args.internalDebuggerPort, 10) || 9090;
-
-
-            reinitializeServer.listen(debugServerListeningPort);
-            reinitializeServer.on("error", (err: Error) => {
-                TelemetryHelper.sendSimpleEvent("reinitializeServerError");
-                this.sendEvent(new vscodeDebugAdapterPackage.OutputEvent("Error in debug adapter server: " + err.toString(), "stderr"));
-                this.sendEvent(new vscodeDebugAdapterPackage.OutputEvent("Breakpoints may not update. Consider restarting and specifying a different 'internalDebuggerPort' in launch.json"));
-            });
-
-            // We do not permit arbitrary args to be passed to our process
-            args.args = [
-                args.platform,
-                debugServerListeningPort.toString(),
-                !isNullOrUndefined(args.iosRelativeProjectPath) ? args.iosRelativeProjectPath : IOSPlatform.DEFAULT_IOS_PROJECT_RELATIVE_PATH,
-                args.target || "simulator",
-            ];
-
-            if (!isNullOrUndefined(args.logCatArguments)) { // We add the parameter if it's defined (adapter crashes otherwise)
-                args.args = args.args.concat([parseLogCatArguments(args.logCatArguments)]);
+            // We add the parameter if it's defined (adapter crashes otherwise)
+            if (!nodeDebugWrapper.isNullOrUndefined(args.logCatArguments)) {
+                nodeDebugWrapper.mobilePlatformOptions.logCatArguments = [nodeDebugWrapper.parseLogCatArguments(args.logCatArguments)];
             }
 
-            originalNodeDebugSessionLaunchRequest.call(this, request, args);
+            return TelemetryHelper.generate("launch", (generator) => {
+                const resolver = new PlatformResolver();
+                return nodeDebugWrapper.remoteExtension.getPackagerPort()
+                    .then(packagerPort => {
+                        nodeDebugWrapper.mobilePlatformOptions.packagerPort = packagerPort;
+                        const mobilePlatform = resolver.resolveMobilePlatform(args.platform, nodeDebugWrapper.mobilePlatformOptions);
+                        if (!mobilePlatform) {
+                            throw new RangeError("The target platform could not be read. Did you forget to add it to the launch.json configuration arguments?");
+                        } else {
+                            return Q({})
+                                .then(() => {
+                                    generator.step("checkPlatformCompatibility");
+                                    TargetPlatformHelper.checkTargetPlatformSupport(nodeDebugWrapper.mobilePlatformOptions.platform);
+                                    generator.step("startPackager");
+                                    Log.logMessage("Starting React Native Packager.");
+                                    return nodeDebugWrapper.remoteExtension.startPackager();
+                                })
+                                .then(() => {
+                                    // We've seen that if we don't prewarm the bundle cache, the app fails on the first attempt to connect to the debugger logic
+                                    // and the user needs to Reload JS manually. We prewarm it to prevent that issue
+                                    generator.step("prewarmBundleCache");
+                                    Log.logMessage("Prewarming bundle cache. This may take a while ...");
+                                    return nodeDebugWrapper.remoteExtension.prewarmBundleCache(nodeDebugWrapper.mobilePlatformOptions.platform);
+                                })
+                                .then(() => {
+                                    generator.step("mobilePlatform.runApp");
+                                    Log.logMessage("Building and running application.");
+                                    return mobilePlatform.runApp();
+                                })
+                                .then(() =>
+                                    nodeDebugWrapper.attachRequest(this, request, args, mobilePlatform));
+                        }
+                    }).catch(error =>
+                        nodeDebugWrapper.bailOut(this, error.message));
+            });
+        };
+    }
+
+    /**
+     * Intecept the "attachRequest" instance method of NodeDebugSession to interpret arguments
+     */
+    private customizeAttachRequest(): void {
+        const nodeDebugWrapper = this;
+        this.nodeDebugSession.prototype.attachRequest = function (request: any, args: IAttachRequestArgs) {
+            nodeDebugWrapper.requestSetup(this, args);
+            nodeDebugWrapper.attachRequest(this, request, args, null);
+        };
+    }
+
+    /**
+     * Intecept the "disconnectRequest" instance method of NodeDebugSession to interpret arguments
+     */
+    private customizeDisconnectRequest(): void {
+        const originalRequest = this.nodeDebugSession.prototype.disconnectRequest;
+        const nodeDebugWrapper = this;
+
+        this.nodeDebugSession.prototype.disconnectRequest = function (response: any, args: any): void {
+            // First we tell the extension to stop monitoring the logcat, and then we disconnect the debugging session
+
+            if (nodeDebugWrapper.mobilePlatformOptions.platform === "android") {
+                nodeDebugWrapper.remoteExtension.stopMonitoringLogcat()
+                    .catch(reason =>
+                        Log.logError(`WARNING: Couldn't stop monitoring logcat: ${reason.message || reason}\n`))
+                    .finally(() =>
+                        originalRequest.call(this, response, args));
+            } else {
+                originalRequest.call(this, response, args);
+            }
+        };
+    }
+
+    /**
+     * Makes the required setup for request customization
+     * - Enables telemetry
+     * - Sets up mobilePlatformOptions, remote extension and projectRootPath
+     * - Starts debug server
+     * - Create global logger
+     */
+    private requestSetup(debugSession: NodeDebugSession, args: any) {
+        this.projectRootPath = path.resolve(args.program, "../..");
+        this.remoteExtension = RemoteExtension.atProjectRootPath(this.projectRootPath);
+        this.mobilePlatformOptions = {
+            projectRoot: this.projectRootPath,
+            platform: args.platform,
         };
 
-        // Intecept the "launchRequest" instance method of NodeDebugSession to interpret arguments
-        const originalNodeDebugSessionDisconnectRequest = nodeDebug.NodeDebugSession.prototype.disconnectRequest;
-        function customDisconnectRequest(response: any, args: any): void {
-            try {
-                // First we tell the extension to stop monitoring the logcat, and then we disconnect the debugging session
-                const remoteExtension = RemoteExtension.atProjectRootPath(projectRootPath);
-                remoteExtension.stopMonitoringLogcat()
-                    .finally(() => originalNodeDebugSessionDisconnectRequest.call(this, response, args))
-                    .done(() => { }, reason => // We just print a warning if something fails
-                        process.stderr.write(`WARNING: Couldn't stop monitoring logcat: ${reason.message || reason}\n`));
-            } catch (exception) {
-                // This is a "nice to have" feature, so we just fire the message and forget. We don't event handle
-                // errors in the response promise
-                process.stderr.write(`WARNING: Couldn't stop monitoring logcat. Sync exception: ${exception.message || exception}\n`);
-                originalNodeDebugSessionDisconnectRequest.call(this, response, args);
-            }
-        }
-        nodeDebug.NodeDebugSession.prototype.disconnectRequest = customDisconnectRequest;
+        // Start to send telemetry
+        this.telemetryReporter.reassignTo(new ExtensionTelemetryReporter(
+            this.appName, this.version, Telemetry.APPINSIGHTS_INSTRUMENTATIONKEY, this.projectRootPath));
 
-        vscodeDebugAdapterPackage.DebugSession.run(nodeDebug.NodeDebugSession);
-    });
+        // Create a server waiting for messages to re-initialize the debug session;
+        const debugServerListeningPort = this.createReinitializeServer(debugSession, args.internalDebuggerPort);
+        args.args = [debugServerListeningPort.toString()];
+
+        Log.SetGlobalLogger(new NodeDebugAdapterLogger(this.vscodeDebugAdapterPackage, debugSession));
+    }
+
+    /**
+     * Runs logic needed to attach.
+     * Attach should:
+     * - Enable js debugging
+     */
+    private attachRequest(debugSession: NodeDebugSession, request: any, args: any, mobilePlatform: any): Q.Promise<void> {
+        return TelemetryHelper.generate("attach", (generator) => {
+            return Q({})
+                .then(() => {
+                    generator.step("mobilePlatform.enableJSDebuggingMode");
+                    if (mobilePlatform) {
+                        return mobilePlatform.enableJSDebuggingMode();
+                    } else {
+                        Log.logMessage("Debugger ready. Enable remote debugging in app.");
+                    }
+                }).then(() =>
+                    this.originalLaunchRequest.call(debugSession, request, args))
+                .catch(error =>
+                    this.bailOut(debugSession, error.message));
+        });
+    }
+
+    /**
+     * Creates internal debug server and returns the port that the server is hook up into.
+     */
+    private createReinitializeServer(debugSession: NodeDebugSession, internalDebuggerPort: string): number {
+        // Create the server
+        const server = http.createServer((req, res) => {
+            res.statusCode = 404;
+            if (req.url === "/refreshBreakpoints") {
+                res.statusCode = 200;
+                if (debugSession) {
+                    const sourceMaps = debugSession._sourceMaps;
+                    if (sourceMaps) {
+                        // Flush any cached source maps
+                        sourceMaps._allSourceMaps = {};
+                        sourceMaps._generatedToSourceMaps = {};
+                        sourceMaps._sourceToGeneratedMaps = {};
+                    }
+                    // Send an "initialized" event to trigger breakpoints to be re-sent
+                    debugSession.sendEvent(new this.vscodeDebugAdapterPackage.InitializedEvent());
+                }
+            }
+            res.end();
+        });
+
+        // Setup listen port and on error response
+        const port = parseInt(internalDebuggerPort, 10) || 9090;
+
+        server.listen(port);
+        server.on("error", (err: Error) => {
+            TelemetryHelper.sendSimpleEvent("reinitializeServerError");
+            Log.logError("Error in debug adapter server: " + err.toString());
+            Log.logMessage("Breakpoints may not update. Consider restarting and specifying a different 'internalDebuggerPort' in launch.json");
+        });
+
+        // Return listen port
+        return port;
+    }
+
+    /**
+     * Logs error to user and finishes the debugging process.
+     */
+    private bailOut(debugSession: NodeDebugSession, message: string): void {
+        Log.logError(`Could not debug. ${message}`);
+        debugSession.sendEvent(new this.vscodeDebugAdapterPackage.TerminatedEvent());
+        process.exit(1);
+    }
+
+    /**
+     * Parses log cat arguments to a string
+     */
+    private parseLogCatArguments(userProvidedLogCatArguments: any): string {
+        return Array.isArray(userProvidedLogCatArguments)
+            ? userProvidedLogCatArguments.join(" ") // If it's an array, we join the arguments
+            : userProvidedLogCatArguments; // If not, we leave it as-is
+    }
+
+    /**
+     * Helper method to know if a value is either null or undefined
+     */
+    private isNullOrUndefined(value: any): boolean {
+        return typeof value === "undefined" || value === null;
+    }
+}

--- a/src/debugger/reactNativeDebugEntryPoint.ts
+++ b/src/debugger/reactNativeDebugEntryPoint.ts
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+import * as fs from "fs";
+import * as path from "path";
+
+import {TelemetryHelper} from "../common/telemetryHelper";
+import {EntryPointHandler, ProcessType} from "../common/entryPointHandler";
+import {ErrorHelper} from "../common/error/errorHelper";
+import {InternalErrorCode} from "../common/error/internalErrorCode";
+import {NullTelemetryReporter, ReassignableTelemetryReporter} from "../common/telemetryReporters";
+import {NodeDebugWrapper} from "./nodeDebugWrapper";
+
+const version = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "..", "package.json"), "utf-8")).version;
+const telemetryReporter = new ReassignableTelemetryReporter(new NullTelemetryReporter());
+const appName = "react-native-debug-adapter";
+
+function bailOut(reason: string): void {
+    // Things have gone wrong in initialization: Report the error to telemetry and exit
+    TelemetryHelper.sendSimpleEvent(reason);
+    process.exit(1);
+}
+
+// Enable telemetry
+new EntryPointHandler(ProcessType.Debugger).runApp(appName, () => version,
+    ErrorHelper.getInternalError(InternalErrorCode.DebuggingFailed), telemetryReporter, () => {
+
+        /**
+         * For debugging React Native we basically want to debug node plus some other stuff.
+         * There is no need to create a new adapter for node because ther already exists one.
+         * We look for node debug adapter on client's computer so we can jump of on top of that.
+         */
+        let nodeDebugFolder: string;
+        let vscodeDebugAdapterPackage: typeof VSCodeDebugAdapter;
+
+        // nodeDebugLocation.json is dynamically generated on extension activation.
+        // If it fails, we must not have been in a react native project
+        try {
+            /* tslint:disable:no-var-requires */
+            nodeDebugFolder = require("./nodeDebugLocation.json").nodeDebugPath;
+            vscodeDebugAdapterPackage = require(path.join(nodeDebugFolder, "node_modules", "vscode-debugadapter"));
+            /* tslint:enable:no-var-requires */
+        } catch (e) {
+            // Nothing we can do here: can't even communicate back because we don't know how to speak debug adapter
+            bailOut("cannotFindDebugAdapter");
+        }
+
+        /**
+         * We did find node debug adapter. Lets get the debugSession from it.
+         * And add our customizations to the requests.
+         */
+
+        // Temporarily dummy out the DebugSession.run function so we do not start the debug adapter until we are ready
+        const originalDebugSessionRun = vscodeDebugAdapterPackage.DebugSession.run;
+        vscodeDebugAdapterPackage.DebugSession.run = () => { };
+
+        let nodeDebug: { NodeDebugSession: typeof NodeDebugSession };
+
+        try {
+            /* tslint:disable:no-var-requires */
+            nodeDebug = require(path.join(nodeDebugFolder, "out", "node", "nodeDebug"));
+            /* tslint:enable:no-var-requires */
+        } catch (e) {
+            // Unable to find nodeDebug, but we can make our own communication channel now
+            const debugSession = new vscodeDebugAdapterPackage.DebugSession();
+            // Note: this will not work in the context of debugging the debug adapter and communicating over a socket,
+            // but in that case we have much better ways to investigate errors.
+            debugSession.start(process.stdin, process.stdout);
+            debugSession.sendEvent(new vscodeDebugAdapterPackage.OutputEvent("Unable to start debug adapter: " + e.toString(), "stderr"));
+            debugSession.sendEvent(new vscodeDebugAdapterPackage.TerminatedEvent());
+
+            bailOut("cannotFindNodeDebugAdapter");
+        }
+
+        vscodeDebugAdapterPackage.DebugSession.run = originalDebugSessionRun;
+
+        // Customize node adapter requests
+        try {
+            let nodeDebugWrapper = new NodeDebugWrapper(appName, version, telemetryReporter, vscodeDebugAdapterPackage, nodeDebug.NodeDebugSession);
+            nodeDebugWrapper.customizeNodeAdapterRequests();
+        } catch (e) {
+            const debugSession = new vscodeDebugAdapterPackage.DebugSession();
+            debugSession.sendEvent(new vscodeDebugAdapterPackage.OutputEvent("Unable to start debug adapter: " + e.toString(), "stderr"));
+            debugSession.sendEvent(new vscodeDebugAdapterPackage.TerminatedEvent());
+            bailOut(e.toString());
+        }
+
+        // Run the debug session for the node debug adapter with our modified requests
+        vscodeDebugAdapterPackage.DebugSession.run(nodeDebug.NodeDebugSession);
+    });


### PR DESCRIPTION
The logic for running the debugger was mixed between a process running in the debugger side (`nodeDebugAdapterWrapper.js`) and a process running in the program being debugged (`launcher.js`).

This PR is a refactor of that logic, trying to run as much code as possible in the debugger side. Also making the appropriate distinctions between the attach and the launch request, and trying to use more OOP to add legibility to the code.