### PR TITLE
Don't show a message each time we check for react-native version

### DIFF
--- a/src/common/reactNativeProjectHelper.ts
+++ b/src/common/reactNativeProjectHelper.ts
@@ -12,26 +12,8 @@ export class ReactNativeProjectHelper {
         this.workspaceRoot = workspaceRoot;
     }
 
-    public getReactNativeVersion(): Q.Promise<string> {
-        let deferred = Q.defer<any>();
-
-        let outputStream = new CommandExecutor(this.workspaceRoot).spawnReactCommand("-v").stdout;
-        let output = "";
-
-        outputStream.on("data", (chunk: Buffer) => {
-          output += chunk.toString();
-        });
-
-        outputStream.on("end", () => {
-            const match = output.match(/react-native: ([\d\.]+)/);
-            deferred.resolve(match && match[1]);
-        });
-
-        outputStream.on("error", (err: Error) => {
-            deferred.reject(err);
-        });
-
-        return deferred.promise;
+    public getReactNativeVersion() {
+        return new CommandExecutor(this.workspaceRoot).getReactNativeVersion();
     }
 
     /**
@@ -40,7 +22,10 @@ export class ReactNativeProjectHelper {
      * {operation} - a function that performs the expected operation
      */
     public isReactNativeProject(): Q.Promise<boolean> {
-        return this.getReactNativeVersion().then(version => !!(version));
+        return this.getReactNativeVersion().
+        then(version => {
+            return !!(version);
+        });
     }
 
     public validateReactNativeVersion(): Q.Promise<void> {


### PR DESCRIPTION
https://github.com/Microsoft/vscode-react-native/pull/253 added some functionality to check for react native version using `react-native -v` command.

Because it was using `spawnReactCommand`, every time we checked for the version, some logs would appear to the user telling it the command was run, adding unnecessary stuff to the user's view.

This PR refactors this logic to do the same but avoid logging the message to the user.