### PR TITLE
don't overwrite existing react and react-native typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Once you have enabled IntelliSense by following the above steps, you can start t
 
 Here is what happens behind the scenes to enable JSX support:
 1. If there is no tsconfig.json file in the project root, one is created with `allowJs: true` to allow TypeScript to process JavaScript files.
-2. Typings for React Native are copied into the .vscode directory.
+2. Typings for React and React Native are copied into the .vscode directory (only if they don't already exist, we check for a `react` or `react-native` directory under `.vscode/typings`)
 
 ## Customization
 

--- a/src/extension/intellisenseHelper.ts
+++ b/src/extension/intellisenseHelper.ts
@@ -64,11 +64,29 @@ export class IntellisenseHelper {
      * Helper method that install typings for React Native.
      */
     public static installReactNativeTypings(): Q.Promise<void> {
-        let reactTypingsSource = path.resolve(__dirname, "..", "..", "ReactTypings");
-        let reactTypingsDest = path.resolve(vscode.workspace.rootPath, ".vscode", "typings");
+        const typingsSource = path.resolve(__dirname, "..", "..", "ReactTypings");
+        const reactTypings = path.resolve(typingsSource, "react");
+        const reactNativeTypings = path.resolve(typingsSource, "react-native");
+
+        const typingsDestination = path.resolve(vscode.workspace.rootPath, ".vscode", "typings");
+        const reactTypingsDestination = path.resolve(typingsDestination, "react");
+        const reactNativeTypingsDestination = path.resolve(typingsDestination, "react-native");
+
         let fileSystem = new FileSystem();
 
-        return fileSystem.copyRecursive(reactTypingsSource, reactTypingsDest);
+        const copyReactTypingsIfNeeded = fileSystem.directoryExists(reactTypingsDestination)
+            .then((exists) => {
+                if (!exists) {
+                    return fileSystem.copyRecursive(reactTypings, reactTypingsDestination);
+                }
+            });
+        const copyReactNativeTypingsIfNeeded = fileSystem.directoryExists(reactNativeTypingsDestination)
+            .then((exists) => {
+                if (!exists) {
+                    return fileSystem.copyRecursive(reactNativeTypings, reactNativeTypingsDestination);
+                }
+            });
+        return Q.all([copyReactTypingsIfNeeded, copyReactNativeTypingsIfNeeded]).then(() => { });
     }
 
     /**


### PR DESCRIPTION
If there are already typings for the react-native project we don't want to overwrite them. This let's VSCode have a default typing but give the opportunity to the user to update them or use any typings as desired.