### PR TITLE
Defer output channel conversion

### DIFF
--- a/src/extension/outputChannelLogger.ts
+++ b/src/extension/outputChannelLogger.ts
@@ -8,6 +8,40 @@
 import {ILogger} from "../common/log/loggers";
 import {LogHelper, LogLevel} from "../common/log/logHelper";
 import {OutputChannel} from "vscode";
+import * as vscode from "vscode";
+
+export class DelayedOutputChannelLogger implements ILogger {
+    private outputChannelLogger: OutputChannelLogger;
+
+    constructor(private channelName: string) {}
+
+    public logInternalMessage(logLevel: LogLevel, message: string) {
+        this.logger.logInternalMessage(logLevel, message);
+    }
+
+    public logMessage(message: string, formatMessage: boolean = true ) {
+        this.logger.logMessage(message, formatMessage);
+    }
+
+    public logError(errorMessage: string, error?: any, logStack: boolean = true) {
+       this.logger.logError(errorMessage, error, logStack);
+    }
+
+    public logStreamData(data: Buffer, stream: NodeJS.WritableStream) {
+        this.logger.logStreamData(data, stream);
+    }
+
+    public setFocusOnLogChannel() {
+        this.logger.setFocusOnLogChannel();
+    }
+
+    private get logger(): OutputChannelLogger {
+        if (!this.outputChannelLogger) {
+            this.outputChannelLogger = new OutputChannelLogger(vscode.window.createOutputChannel(this.channelName));
+        }
+        return this.outputChannelLogger;
+    }
+}
 
 export class OutputChannelLogger implements ILogger {
     private outputChannel: OutputChannel;

--- a/src/extension/rn-extension.ts
+++ b/src/extension/rn-extension.ts
@@ -33,7 +33,7 @@ import {IntellisenseHelper} from "./intellisenseHelper";
 import {Telemetry} from "../common/telemetry";
 import {TelemetryHelper} from "../common/telemetryHelper";
 import {ExtensionServer} from "./extensionServer";
-import {OutputChannelLogger} from "./outputChannelLogger";
+import {DelayedOutputChannelLogger} from "./outputChannelLogger";
 
 /* all components use the same packager instance */
 const projectRootPath = vscode.workspace.rootPath;
@@ -41,7 +41,7 @@ const globalPackager = new Packager(projectRootPath);
 const packagerStatusIndicator = new PackagerStatusIndicator();
 const commandPaletteHandler = new CommandPaletteHandler(projectRootPath, globalPackager, packagerStatusIndicator);
 
-const outputChannelLogger = new OutputChannelLogger(vscode.window.createOutputChannel("React-Native"));
+const outputChannelLogger = new DelayedOutputChannelLogger("React-Native");
 const entryPointHandler = new EntryPointHandler(ProcessType.Extension, outputChannelLogger);
 const reactNativeProjectHelper = new ReactNativeProjectHelper(projectRootPath);
 const fsUtil = new FileSystem();
@@ -51,6 +51,7 @@ interface ISetupableDisposable extends vscode.Disposable {
 }
 
 export function activate(context: vscode.ExtensionContext): void {
+
     entryPointHandler.runApp("react-native", () => <string>require("../../package.json").version,
         ErrorHelper.getInternalError(InternalErrorCode.ExtensionActivationFailed), projectRootPath, () => {
         return reactNativeProjectHelper.isReactNativeProject()


### PR DESCRIPTION
Instead of creating an output channel once our extension is loaded, with this change we defer it to when it is required. When the output channel is created it triggers the output pane to come into view, so by defering it we avoid cluttering the screen until there is something worth looking at.

Fixes #258