### PR TITLE
Updating project detection to work with workspaces

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -96,7 +96,7 @@ function test() {
         }));
 }
 
-gulp.task('test', ['build'], test);
+gulp.task('test', ['build', 'tslint'], test);
 gulp.task('test-no-build', test);
 
 gulp.task('check-imports', function (cb) {

--- a/src/common/ios/plistBuddy.ts
+++ b/src/common/ios/plistBuddy.ts
@@ -6,7 +6,7 @@ import * as Q from "q";
 
 import {Node} from "../../common/node/node";
 import {ChildProcess} from "../../common/node/childProcess";
-import {Xcodeproj} from "./xcodeproj";
+import {Xcodeproj, IXcodeProjFile} from "./xcodeproj";
 
 export class PlistBuddy {
     private static plistBuddyExecutable = "/usr/libexec/PlistBuddy";
@@ -23,11 +23,10 @@ export class PlistBuddy {
     }
 
     public getBundleId(projectRoot: string, simulator: boolean = true): Q.Promise<string> {
-        return this.xcodeproj.findXcodeprojFile(projectRoot).then((projectFile: string) => {
-            const appName = path.basename(projectFile, path.extname(projectFile));
+        return this.xcodeproj.findXcodeprojFile(projectRoot).then((projectFile: IXcodeProjFile) => {
             const infoPlistPath = path.join(projectRoot, "build", "Build", "Products",
                 simulator ? "Debug-iphonesimulator" : "Debug-iphoneos",
-                `${appName}.app`, "Info.plist");
+                `${projectFile.projectName}.app`, "Info.plist");
 
             return this.invokePlistBuddy("Print:CFBundleIdentifier", infoPlistPath);
         });

--- a/src/common/ios/xcodeproj.ts
+++ b/src/common/ios/xcodeproj.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
+import * as path from "path";
 import * as Q from "q";
 
 import {ErrorHelper} from "../../common/error/errorHelper";
@@ -8,6 +9,12 @@ import {Log} from "../../common/log/log";
 import {FileSystem} from "../../common/node/fileSystem";
 
 import {TelemetryHelper} from "../../common/telemetryHelper";
+
+export interface IXcodeProjFile {
+    filename: string,
+    filetype: string,
+    projectName: string
+}
 
 export class Xcodeproj {
     private nodeFileSystem: FileSystem;
@@ -18,15 +25,26 @@ export class Xcodeproj {
         this.nodeFileSystem = nodeFileSystem;
     }
 
-    public findXcodeprojFile(projectRoot: string): Q.Promise<string> {
+    public findXcodeprojFile(projectRoot: string): Q.Promise<IXcodeProjFile> {
         return this.nodeFileSystem
-            .findFilesByExtension(projectRoot, "xcodeproj")
-            .then((projectFiles: string[]) => {
-                if (projectFiles.length > 1) {
-                    TelemetryHelper.sendSimpleEvent("multipleXcodeprojFound");
-                    Log.logWarning(ErrorHelper.getWarning(`More than one xcodeproj found. Using ${projectFiles[0]}`));
+            .readDir(projectRoot)
+            .then((files: string[]): IXcodeProjFile => {
+                const sorted = files.sort();
+                const candidate = sorted.find((file: string) =>
+                    [".xcodeproj", ".xcworkspace"].indexOf(path.extname(file)) !== -1
+                );
+                if (!candidate) {
+                    throw new Error("Unable to find any xcodeproj or xcworkspace files.");
                 }
-                return projectFiles[0];
+
+                const filename = path.join(projectRoot, candidate)
+                const filetype = path.extname(candidate);
+                const projectName = path.basename(candidate, filetype)
+                return {
+                    filename,
+                    filetype,
+                    projectName
+                }
             });
     }
 }

--- a/src/common/ios/xcodeproj.ts
+++ b/src/common/ios/xcodeproj.ts
@@ -7,8 +7,8 @@ import * as Q from "q";
 import {FileSystem} from "../../common/node/fileSystem";
 
 export interface IXcodeProjFile {
-    filename: string;
-    filetype: string;
+    fileName: string;
+    fileType: string;
     projectName: string;
 }
 
@@ -33,12 +33,12 @@ export class Xcodeproj {
                     throw new Error("Unable to find any xcodeproj or xcworkspace files.");
                 }
 
-                const filename = path.join(projectRoot, candidate);
-                const filetype = path.extname(candidate);
-                const projectName = path.basename(candidate, filetype);
+                const fileName = path.join(projectRoot, candidate);
+                const fileType = path.extname(candidate);
+                const projectName = path.basename(candidate, fileType);
                 return {
-                    filename,
-                    filetype,
+                    fileName,
+                    fileType,
                     projectName,
                 };
             });

--- a/src/common/ios/xcodeproj.ts
+++ b/src/common/ios/xcodeproj.ts
@@ -4,16 +4,12 @@
 import * as path from "path";
 import * as Q from "q";
 
-import {ErrorHelper} from "../../common/error/errorHelper";
-import {Log} from "../../common/log/log";
 import {FileSystem} from "../../common/node/fileSystem";
 
-import {TelemetryHelper} from "../../common/telemetryHelper";
-
 export interface IXcodeProjFile {
-    filename: string,
-    filetype: string,
-    projectName: string
+    filename: string;
+    filetype: string;
+    projectName: string;
 }
 
 export class Xcodeproj {
@@ -37,14 +33,14 @@ export class Xcodeproj {
                     throw new Error("Unable to find any xcodeproj or xcworkspace files.");
                 }
 
-                const filename = path.join(projectRoot, candidate)
+                const filename = path.join(projectRoot, candidate);
                 const filetype = path.extname(candidate);
-                const projectName = path.basename(candidate, filetype)
+                const projectName = path.basename(candidate, filetype);
                 return {
                     filename,
                     filetype,
-                    projectName
-                }
+                    projectName,
+                };
             });
     }
 }

--- a/src/common/node/fileSystem.ts
+++ b/src/common/node/fileSystem.ts
@@ -130,16 +130,6 @@ export class FileSystem {
         return Q.nfcall<void>(this.fs.unlink, filename);
     }
 
-    public findFilesByExtension(folder: string, extension: string): Q.Promise<string[]> {
-        return Q.nfcall(this.fs.readdir, folder).then((files: string[]) => {
-            const extFiles = files.filter((file: string) => path.extname(file) === `.${extension}`);
-            if (extFiles.length === 0) {
-                throw new Error(`Unable to find any ${extension} files.`);
-            }
-            return extFiles;
-        });
-    }
-
     public mkDir(p: string): Q.Promise<void> {
         return Q.nfcall<void>(this.fs.mkdir, p);
     }

--- a/src/debugger/ios/compiler.ts
+++ b/src/debugger/ios/compiler.ts
@@ -26,7 +26,7 @@ export class Compiler {
     private xcodeBuildArguments(): Q.Promise<string[]> {
         return new Xcodeproj().findXcodeprojFile(this.projectRoot).then((projectFile: IXcodeProjFile) => {
             return [
-                projectFile.filetype === ".xcworkspace" ? "-workspace" : "-project", path.join(this.projectRoot, projectFile),
+                projectFile.fileType === ".xcworkspace" ? "-workspace" : "-project", projectFile.fileName,
                 "-scheme", projectFile.projectName,
                 "-destination", "generic/platform=iOS", // Build for a generic iOS device
                 "-derivedDataPath", path.join(this.projectRoot, "build"),

--- a/src/debugger/ios/compiler.ts
+++ b/src/debugger/ios/compiler.ts
@@ -5,7 +5,7 @@ import * as path from "path";
 import * as Q from "q";
 
 import {CommandExecutor} from "../../common/commandExecutor";
-import {Xcodeproj} from "../../common/ios/xcodeproj";
+import {Xcodeproj, IXcodeProjFile} from "../../common/ios/xcodeproj";
 
 export class Compiler {
     private projectRoot: string;
@@ -24,11 +24,10 @@ export class Compiler {
         Return the appropriate arguments for compiling a react native project
     */
     private xcodeBuildArguments(): Q.Promise<string[]> {
-        return new Xcodeproj().findXcodeprojFile(this.projectRoot).then((projectFile: string) => {
-            const projectName = path.basename(projectFile, path.extname(projectFile));
+        return new Xcodeproj().findXcodeprojFile(this.projectRoot).then((projectFile: IXcodeProjFile) => {
             return [
-                "-project", path.join(this.projectRoot, projectFile),
-                "-scheme", projectName,
+                projectFile.filetype === ".xcworkspace" ? "-workspace" : "-project", path.join(this.projectRoot, projectFile),
+                "-scheme", projectFile.projectName,
                 "-destination", "generic/platform=iOS", // Build for a generic iOS device
                 "-derivedDataPath", path.join(this.projectRoot, "build"),
             ];

--- a/src/debugger/ios/deviceDeployer.ts
+++ b/src/debugger/ios/deviceDeployer.ts
@@ -5,7 +5,7 @@ import * as path from "path";
 import * as Q from "q";
 
 import {CommandExecutor} from "../../common/commandExecutor";
-import {Xcodeproj} from "../../common/ios/xcodeproj";
+import {Xcodeproj, IXcodeProjFile} from "../../common/ios/xcodeproj";
 import {ErrorHelper} from "../../common/error/errorHelper";
 import {InternalErrorCode} from "../../common/error/internalErrorCode";
 
@@ -17,10 +17,9 @@ export class DeviceDeployer {
     }
 
     public deploy(): Q.Promise<void> {
-        return new Xcodeproj().findXcodeprojFile(this.projectRoot).then((projectFile: string) => {
-            const projectName = path.basename(projectFile, path.extname(projectFile));
+        return new Xcodeproj().findXcodeprojFile(this.projectRoot).then((projectFile: IXcodeProjFile) => {
             const pathToCompiledApp = path.join(this.projectRoot, "build",
-                "Build", "Products", "Debug-iphoneos", `${projectName}.app`);
+                "Build", "Products", "Debug-iphoneos", `${projectFile.projectName}.app`);
             return new CommandExecutor(this.projectRoot)
                 .spawn("ideviceinstaller", ["-i", pathToCompiledApp]).catch((err) => {
                     if ((<any>err).errorCode === InternalErrorCode.CommandFailed && (<any>err).innerError.code === "ENOENT") {

--- a/src/test/common/ios/plistBuddy.test.ts
+++ b/src/test/common/ios/plistBuddy.test.ts
@@ -84,7 +84,7 @@ suite("plistBuddy", function() {
             mockedFindXcodeprojFile.withArgs(projectRoot).returns(Q.resolve({
                     filename: appName + ".xcodeproj",
                     filetype: ".xcodeproj",
-                    projectName: appName
+                    projectName: appName,
                 }));
             const mockXcodeproj: any = {
                 findXcodeprojFile: mockedFindXcodeprojFile,

--- a/src/test/common/ios/plistBuddy.test.ts
+++ b/src/test/common/ios/plistBuddy.test.ts
@@ -81,7 +81,11 @@ suite("plistBuddy", function() {
             };
 
             const mockedFindXcodeprojFile = sinon.stub();
-            mockedFindXcodeprojFile.withArgs(projectRoot).returns(Q.resolve(appName + ".xcodeproj"));
+            mockedFindXcodeprojFile.withArgs(projectRoot).returns(Q.resolve({
+                    filename: appName + ".xcodeproj",
+                    filetype: ".xcodeproj",
+                    projectName: appName
+                }));
             const mockXcodeproj: any = {
                 findXcodeprojFile: mockedFindXcodeprojFile,
             };

--- a/src/test/common/ios/plistBuddy.test.ts
+++ b/src/test/common/ios/plistBuddy.test.ts
@@ -3,6 +3,8 @@
 
 import {PlistBuddy} from "../../../common/ios/plistBuddy";
 
+import {IXcodeProjFile} from "../../../common/ios/xcodeproj";
+
 import * as assert from "assert";
 import * as path from "path";
 import * as Q from "q";
@@ -81,11 +83,12 @@ suite("plistBuddy", function() {
             };
 
             const mockedFindXcodeprojFile = sinon.stub();
-            mockedFindXcodeprojFile.withArgs(projectRoot).returns(Q.resolve({
-                    filename: appName + ".xcodeproj",
-                    filetype: ".xcodeproj",
+            const mockedProjResult: IXcodeProjFile = {
+                    fileName: appName + ".xcodeproj",
+                    fileType: ".xcodeproj",
                     projectName: appName,
-                }));
+                };
+            mockedFindXcodeprojFile.withArgs(projectRoot).returns(Q.resolve(mockedProjResult));
             const mockXcodeproj: any = {
                 findXcodeprojFile: mockedFindXcodeprojFile,
             };

--- a/src/test/common/ios/xcodeproj.test.ts
+++ b/src/test/common/ios/xcodeproj.test.ts
@@ -11,7 +11,9 @@ suite("xcodeproj", function() {
     suite("commonContext", function() {
         test("should look in the correct location for xcodeproj files and return one", function() {
             const projectRoot = path.join("/", "tmp", "myProject");
-            const testFiles = ["foo.xcodeproj"];
+            const projectName = "foo";
+            const fileType = ".xcodeproj";
+            const testFiles = [projectName + fileType];
             const mockFileSystem: any = {
                 readDir: (path: string) => {
                     return Q(testFiles);
@@ -23,9 +25,9 @@ suite("xcodeproj", function() {
             return xcodeproj.findXcodeprojFile(projectRoot)
                 .then((proj) => {
                     assert.deepEqual(proj, {
-                        filename: path.join(projectRoot, testFiles[0]),
-                        filetype: ".xcodeproj",
-                        projectName: "foo",
+                        fileName: path.join(projectRoot, testFiles[0]),
+                        fileType,
+                        projectName,
                     });
                 });
         });

--- a/src/test/common/ios/xcodeproj.test.ts
+++ b/src/test/common/ios/xcodeproj.test.ts
@@ -15,7 +15,7 @@ suite("xcodeproj", function() {
             const mockFileSystem: any = {
                 readDir: (path: string) => {
                     return Q(testFiles);
-                }
+                },
             };
 
             const xcodeproj = new Xcodeproj({ nodeFileSystem: mockFileSystem });
@@ -25,7 +25,7 @@ suite("xcodeproj", function() {
                     assert.deepEqual(proj, {
                         filename: path.join(projectRoot, testFiles[0]),
                         filetype: ".xcodeproj",
-                        projectName: "foo"
+                        projectName: "foo",
                     });
                 });
         });

--- a/src/test/common/ios/xcodeproj.test.ts
+++ b/src/test/common/ios/xcodeproj.test.ts
@@ -11,22 +11,22 @@ suite("xcodeproj", function() {
     suite("commonContext", function() {
         test("should look in the correct location for xcodeproj files and return one", function() {
             const projectRoot = path.join("/", "tmp", "myProject");
-            const extension = "xcodeproj";
             const testFiles = ["foo.xcodeproj"];
             const mockFileSystem: any = {
-                findFilesByExtension: (path: string, ext: string) => {
-                    if (extension !== ext) {
-                        throw new Error(`Expected ${extension} got ${ext}`);
-                    }
+                readDir: (path: string) => {
                     return Q(testFiles);
-                },
+                }
             };
 
             const xcodeproj = new Xcodeproj({ nodeFileSystem: mockFileSystem });
 
             return xcodeproj.findXcodeprojFile(projectRoot)
-                .then((file) => {
-                    assert.equal(file, testFiles[0]);
+                .then((proj) => {
+                    assert.deepEqual(proj, {
+                        filename: path.join(projectRoot, testFiles[0]),
+                        filetype: ".xcodeproj",
+                        projectName: "foo"
+                    });
                 });
         });
     });


### PR DESCRIPTION
We now follow similar logic to react-native's cli when performing iOS builds, and pick either the .xcodeproj or .xcworkspace, whichever we find first.

Fixes #264 