### PR TITLE
Adding support for --variant

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,6 +165,10 @@
                                 "type": "string",
                                 "description": "Relative path to the ios/ folder, if it is not located on the project root.",
                                 "default": "ios"
+                            },
+                            "variant": {
+                                "type": "string",
+                                "description": "A variant to be passed to react-native run-android, e.g. 'devDebug' to specify --variant=devDebug"
                             }
                         }
                     }

--- a/src/common/android/androidPlatform.ts
+++ b/src/common/android/androidPlatform.ts
@@ -57,7 +57,7 @@ export class AndroidPlatform extends GeneralMobilePlatform {
 
     public runApp(shouldLaunchInAllDevices: boolean = false): Q.Promise<void> {
         return TelemetryHelper.generate("AndroidPlatform.runApp", () => {
-            const runAndroidSpawn = this.reactNative.runAndroid(this.runOptions.projectRoot);
+            const runAndroidSpawn = this.reactNative.runAndroid(this.runOptions.projectRoot, this.runOptions.variant);
             const output = new OutputVerifier(
                 () =>
                     Q(AndroidPlatform.RUN_ANDROID_SUCCESS_PATTERNS),

--- a/src/common/launchArgs.ts
+++ b/src/common/launchArgs.ts
@@ -7,6 +7,7 @@
 export interface IRunOptions extends ILaunchArgs {
     projectRoot: string;
     iosRelativeProjectPath?: string;
+    variant?: string;
 }
 
 /**

--- a/src/common/reactNative.ts
+++ b/src/common/reactNative.ts
@@ -7,14 +7,18 @@ import {CommandExecutor} from "./commandExecutor";
 import {ISpawnResult} from "./node/childProcess";
 
 export interface IReactNative {
-    runAndroid(projectRoot: string): ISpawnResult;
+    runAndroid(projectRoot: string, variant?: string): ISpawnResult;
     createProject(projectRoot: string, projectName: string): Q.Promise<void>;
 }
 
 export class ReactNative implements IReactNative {
-    public runAndroid(projectRoot: string): ISpawnResult {
+    public runAndroid(projectRoot: string, variant?: string): ISpawnResult {
         let cexec = new CommandExecutor(projectRoot);
-        return cexec.spawnReactCommand("run-android");
+        let args: string[] = [];
+        if (variant) {
+            args.push(`--variant=${variant}`);
+        }
+        return cexec.spawnReactCommand("run-android", args);
     }
 
     public createProject(projectRoot: string, projectName: string): Q.Promise<void> {


### PR DESCRIPTION
react-native run-android allows a --variant option, and we now expose that through our launch.json

Fixes #270 