### PR TITLE
Adding strip-json-comments to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,6 +189,7 @@
         "options": "0.0.6",
         "q": "1.4.1",
         "semver": "5.1.0",
+        "strip-json-comments": "2.0.1",
         "typechecker": "2.0.8",
         "ultron": "1.0.2",
         "vscode-extension-telemetry": "0.0.5",


### PR DESCRIPTION
We will be using this package shortly, and it is in our npm-shrinkwrap to make sure we use the right version. Without it also being a dependency, packaging fails due to npm list failing.