### PR TITLE
Added a "restart packager" command.

### DIFF
--- a/errorStrings/errorStrings.json
+++ b/errorStrings/errorStrings.json
@@ -25,6 +25,7 @@
     "FailedToRunOnIos": "Failed to run the application in iOS",
     "FailedToStartPackager": "Failed to start the React Native packager",
     "FailedToStopPackager": "Failed to stop the React Native packager",
+    "FailedToRestartPackager": "Failed to restart the React Native packager",
     "DebuggingFailed": "Cannot debug application",
     "DebuggingFailedInNodeWrapper": "Cannot debug application due to an error in the internal Node Debugger",
     "RNTempFolderDeletionFailed": "Couldn't delete the temporary folder {0}",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,10 @@
             {
                 "command": "reactNative.stopPackager",
                 "title": "React Native: Stop Packager"
+            },
+            {
+                "command": "reactNative.restartPackager",
+                "title": "React Native: Restart Packager"
             }
         ],
         "debuggers": [

--- a/src/common/error/internalErrorCode.ts
+++ b/src/common/error/internalErrorCode.ts
@@ -11,6 +11,7 @@ export enum InternalErrorCode {
         FailedToStartPackager = 106,
         FailedToStopPackager = 107,
         PackagerRunningInDifferentPort = 108,
+        FailedToRestartPackager = 109,
 
         // Device Deployer errors
         IDeviceInstallerNotFound = 201,

--- a/src/common/extensionMessaging.ts
+++ b/src/common/extensionMessaging.ts
@@ -11,6 +11,7 @@ import {Crypto} from "./node/crypto";
 export enum ExtensionMessage {
     START_PACKAGER,
     STOP_PACKAGER,
+    RESTART_PACKAGER,
     PREWARM_BUNDLE_CACHE,
     START_MONITORING_LOGCAT,
     STOP_MONITORING_LOGCAT,

--- a/src/common/packager.ts
+++ b/src/common/packager.ts
@@ -97,7 +97,7 @@ export class Packager {
             if (running) {
                 if (!this.packagerProcess) {
                     Log.logWarning(ErrorHelper.getWarning("Packager is still running. If the packager was started outside VS Code, please quit the packager process using the task manager."));
-                    return Q.resolve<void>(void 1);
+                    return Q.resolve<void>(void 0);
                 }
                 return this.killPackagerProcess();
             } else {

--- a/src/common/packager.ts
+++ b/src/common/packager.ts
@@ -41,7 +41,7 @@ export class Packager {
         return Packager.getHostForPort(this.port);
     }
 
-    public start(port: number, clearCache: boolean): Q.Promise<void> {
+    public start(port: number, resetCache: boolean): Q.Promise<void> {
         if (this.port && this.port !== port) {
             return Q.reject<void>(ErrorHelper.getInternalError(InternalErrorCode.PackagerRunningInDifferentPort, port, this.port));
         }
@@ -55,7 +55,7 @@ export class Packager {
                     return this.monkeyPatchOpnForRNPackager()
                         .then(() => {
                             let args = ["--port", port.toString()];
-                            if (clearCache) {
+                            if (resetCache) {
                                 args = args.concat("--resetCache");
                             }
                             let reactEnv = Object.assign({}, process.env, {
@@ -120,7 +120,7 @@ export class Packager {
                         return Q.resolve<boolean>(false);
                     }
 
-                    return this.killPackagerProcess().then(() => Q.resolve<boolean>(true))
+                    return this.killPackagerProcess().then(() => Q.resolve<boolean>(true));
                 } else {
                     Log.logWarning(ErrorHelper.getWarning("Packager is not running"));
                     return Q.resolve<boolean>(true);

--- a/src/common/packager.ts
+++ b/src/common/packager.ts
@@ -129,8 +129,7 @@ export class Packager {
             .then(stoppedOK => {
                 if (stoppedOK) {
                     return this.start(port, true);
-                }
-                else {
+                } else {
                     return Q.resolve<void>(void 0);
                 }
             });

--- a/src/extension/commandPaletteHandler.ts
+++ b/src/extension/commandPaletteHandler.ts
@@ -42,6 +42,14 @@ export class CommandPaletteHandler {
     }
 
     /**
+     * Restarts the React Native packager
+     */
+    public restartPackager(): Q.Promise<void> {
+        return this.executeCommandInContext("restartPackager", () =>
+            this.runRestartPackagerCommandAndUpdateStatus());
+    }
+
+    /**
      * Executes the 'react-native run-android' command
      */
     public runAndroid(): Q.Promise<void> {
@@ -67,7 +75,12 @@ export class CommandPaletteHandler {
     }
 
     private runStartPackagerCommandAndUpdateStatus(): Q.Promise<void> {
-        return this.reactNativePackager.start(SettingsHelper.getPackagerPort())
+        return this.reactNativePackager.start(SettingsHelper.getPackagerPort(), false)
+            .then(() => this.reactNativePackageStatusIndicator.updatePackagerStatus(PackagerStatus.PACKAGER_STARTED));
+    }
+
+    private runRestartPackagerCommandAndUpdateStatus(): Q.Promise<void> {
+        return this.reactNativePackager.restart(SettingsHelper.getPackagerPort())
             .then(() => this.reactNativePackageStatusIndicator.updatePackagerStatus(PackagerStatus.PACKAGER_STARTED));
     }
 

--- a/src/extension/extensionServer.ts
+++ b/src/extension/extensionServer.ts
@@ -33,6 +33,7 @@ export class ExtensionServer implements vscode.Disposable {
         /* register handlers for all messages */
         this.messageHandlerDictionary[em.ExtensionMessage.START_PACKAGER] = this.startPackager;
         this.messageHandlerDictionary[em.ExtensionMessage.STOP_PACKAGER] = this.stopPackager;
+        this.messageHandlerDictionary[em.ExtensionMessage.RESTART_PACKAGER] = this.restartPackager;
         this.messageHandlerDictionary[em.ExtensionMessage.PREWARM_BUNDLE_CACHE] = this.prewarmBundleCache;
         this.messageHandlerDictionary[em.ExtensionMessage.START_MONITORING_LOGCAT] = this.startMonitoringLogCat;
         this.messageHandlerDictionary[em.ExtensionMessage.STOP_MONITORING_LOGCAT] = this.stopMonitoringLogCat;
@@ -88,7 +89,7 @@ export class ExtensionServer implements vscode.Disposable {
      */
     private startPackager(port?: any): Q.Promise<any> {
         const portToUse = ConfigurationReader.readIntWithDefaultSync(port, SettingsHelper.getPackagerPort());
-        return this.reactNativePackager.start(portToUse)
+        return this.reactNativePackager.start(portToUse, false)
             .then(() =>
                 this.reactNativePackageStatusIndicator.updatePackagerStatus(PackagerStatus.PACKAGER_STARTED));
     }
@@ -99,6 +100,16 @@ export class ExtensionServer implements vscode.Disposable {
     private stopPackager(): Q.Promise<any> {
         return this.reactNativePackager.stop()
             .then(() => this.reactNativePackageStatusIndicator.updatePackagerStatus(PackagerStatus.PACKAGER_STOPPED));
+    }
+
+    /**
+     * Message handler for RESTART_PACKAGER.
+     */
+    private restartPackager(port?: any): Q.Promise<any> {
+        const portToUse = ConfigurationReader.readIntWithDefaultSync(port, SettingsHelper.getPackagerPort());
+        return this.reactNativePackager.restart(portToUse)
+            .then(() =>
+                this.reactNativePackageStatusIndicator.updatePackagerStatus(PackagerStatus.PACKAGER_STARTED));
     }
 
     /**

--- a/src/extension/rn-extension.ts
+++ b/src/extension/rn-extension.ts
@@ -124,6 +124,7 @@ function registerReactNativeCommands(context: vscode.ExtensionContext): void {
     registerVSCodeCommand(context, "runIos", ErrorHelper.getInternalError(InternalErrorCode.FailedToRunOnIos), () => commandPaletteHandler.runIos());
     registerVSCodeCommand(context, "startPackager", ErrorHelper.getInternalError(InternalErrorCode.FailedToStartPackager), () => commandPaletteHandler.startPackager());
     registerVSCodeCommand(context, "stopPackager", ErrorHelper.getInternalError(InternalErrorCode.FailedToStopPackager), () => commandPaletteHandler.stopPackager());
+    registerVSCodeCommand(context, "restartPackager", ErrorHelper.getInternalError(InternalErrorCode.FailedToRestartPackager), () => commandPaletteHandler.restartPackager());
 }
 
 function registerVSCodeCommand(


### PR DESCRIPTION
It's in addition to the existing "start packager" and "stop packager" commands. It also resets the cache when (re)starting, which can fix up various issues like source map not being updated for TypeScript apps, etc.