### PR TITLE
Return a promise from deactivation to ensure vscode will wait until P…

### DIFF
--- a/src/extension/rn-extension.ts
+++ b/src/extension/rn-extension.ts
@@ -83,13 +83,18 @@ export function activate(context: vscode.ExtensionContext): void {
     });
 }
 
-export function deactivate(): void {
-    // Kill any packager processes that we spawned
-    entryPointHandler.runFunction("extension.deactivate",
-        ErrorHelper.getInternalError(InternalErrorCode.FailedToStopPackagerOnExit),
-        () => {
-            commandPaletteHandler.stopPackager();
-        }, /*errorsAreFatal*/ true);
+export function deactivate(): Q.Promise<void> {
+    return Q.Promise<void>(function (resolve) {
+        // Kill any packager processes that we spawned
+        entryPointHandler.runFunction("extension.deactivate",
+            ErrorHelper.getInternalError(InternalErrorCode.FailedToStopPackagerOnExit),
+            () => {
+                commandPaletteHandler.stopPackager().done(() => {
+                    // Tell vscode that we are done with deactivation
+                    resolve(void 0);
+                });
+            }, /*errorsAreFatal*/ true);
+    });
 }
 
 function configureNodeDebuggerLocation(): Q.Promise<void> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
         "SampleApplication/.vscode",
         "ReactTypings",
         "tools/",
-        "src/test/resources/sampleReactNative022Project/"
+        "src/test/resources/sampleReactNative022Project/",
+        ".vscode-test"
     ]
 }


### PR DESCRIPTION
…ackager process is killed

VS Code expects a promise returned from deactivate and waits until it resolved or a timeout occurs before exiting.
Not returning a promise can cause a situation when we have not yet killed Packager while other extensions' deactivates have finished and vscode process exits - this will result in the Packager process being detached from parent and hang in the process tree root.

This closes #300 