### PR TITLE
Fix for breakpoints are not being hit in vscode@>1.6.0-insiders

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,7 @@
             "name": "Debug Debugger",
             "type": "node",
             "request": "launch",
-            "program": "${workspaceRoot}/out/debugger/nodeDebugWrapper.js",
+            "program": "${workspaceRoot}/src/debugger/reactNativeDebugEntryPoint.ts",
             "runtimeArgs": [
                 "--harmony"
             ],

--- a/src/debugger/nodeDebugAdapter.d.ts
+++ b/src/debugger/nodeDebugAdapter.d.ts
@@ -25,9 +25,7 @@ declare module VSCodeDebugAdapter {
 }
 
 declare class SourceMaps {
-    public _sourceToGeneratedMaps: {};
-    public _generatedToSourceMaps: {};
-    public _allSourceMaps: {};
+    constructor(session: NodeDebugSession, generatedCodeDirectory: string, generatedCodeGlobs: string[]);
 }
 
 declare class NodeDebugSession extends VSCodeDebugAdapter.DebugSession {

--- a/src/debugger/reactNativeDebugEntryPoint.ts
+++ b/src/debugger/reactNativeDebugEntryPoint.ts
@@ -55,10 +55,12 @@ new EntryPointHandler(ProcessType.Debugger).runApp(appName, () => version,
         vscodeDebugAdapterPackage.DebugSession.run = () => { };
 
         let nodeDebug: { NodeDebugSession: typeof NodeDebugSession };
+        let sourceMaps: { SourceMaps: typeof SourceMaps };
 
         try {
             /* tslint:disable:no-var-requires */
             nodeDebug = require(path.join(nodeDebugFolder, "out", "node", "nodeDebug"));
+            sourceMaps = require(path.join(nodeDebugFolder, "out", "node", "sourceMaps"));
             /* tslint:enable:no-var-requires */
         } catch (e) {
             // Unable to find nodeDebug, but we can make our own communication channel now
@@ -76,7 +78,8 @@ new EntryPointHandler(ProcessType.Debugger).runApp(appName, () => version,
 
         // Customize node adapter requests
         try {
-            let nodeDebugWrapper = new NodeDebugWrapper(appName, version, telemetryReporter, vscodeDebugAdapterPackage, nodeDebug.NodeDebugSession);
+            let nodeDebugWrapper = new NodeDebugWrapper(appName, version, telemetryReporter,
+                                                        vscodeDebugAdapterPackage, nodeDebug.NodeDebugSession, sourceMaps.SourceMaps);
             nodeDebugWrapper.customizeNodeAdapterRequests();
         } catch (e) {
             const debugSession = new vscodeDebugAdapterPackage.DebugSession();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
         "noFallthroughCasesInSwitch": true
     },
     "exclude": [
+        ".vscode-test",
         "node_modules",
         "SampleApplication/",
         "SampleApplication/node_modules",


### PR DESCRIPTION
Due to some changes in 'vscode-node-debug', we're depending on, source maps for *.bundle files were not being caught by debugger.

This PR changes the way we load these source maps. Instead of cleaning internal source maps cache we now recreating the whole `SourceMaps` instance with proper parameters and forcing it to include maps for *.bundle files as well as for regular JS files.

This fixes #311 