### PR TITLE
Stop packager on React/Exponent environment switch

### DIFF
--- a/src/common/exponent/exponentHelper.ts
+++ b/src/common/exponent/exponentHelper.ts
@@ -64,7 +64,7 @@ export class ExponentHelper {
                 return this.ensureExpJson();
             }).then(() => {
                 Log.logMessage("Project setup is correct. Generating entrypoint code.");
-                this.createIndex();
+                return this.createIndex();
             });
     }
 

--- a/src/common/exponent/exponentPlatform.ts
+++ b/src/common/exponent/exponentPlatform.ts
@@ -30,7 +30,7 @@ export class ExponentPlatform extends GeneralMobilePlatform {
     }
 
     public startPackager(): Q.Promise<void> {
-        Log.logMessage("Starting React Native Packager.");
+        Log.logMessage("Starting Exponent Packager.");
         return this.remoteExtension.startExponentPackager()
             .then(exponentUrl => {
                 if (!exponentUrl) {

--- a/src/common/generalMobilePlatform.ts
+++ b/src/common/generalMobilePlatform.ts
@@ -6,7 +6,6 @@ import * as Q from "q";
 import {Log} from "../common/log/log";
 import {IRunOptions} from "../common/launchArgs";
 import {RemoteExtension} from "../common/remoteExtension";
-import {Packager} from "../common/packager";
 
 export class GeneralMobilePlatform {
     protected projectPath: string;
@@ -30,17 +29,8 @@ export class GeneralMobilePlatform {
     }
 
     public startPackager(): Q.Promise<void> {
-        return this.remoteExtension.getPackagerPort().then(port => {
-            return Packager.isPackagerRunning(Packager.getHostForPort(port))
-                .then(isRunning => {
-                    if (isRunning) {
-                        Log.logMessage("Attaching to running packager at port: " + port);
-                        return Q.resolve<void>(void 0);
-                    }
-                    Log.logMessage("Starting React Native Packager.");
-                    return this.remoteExtension.startPackager();
-                });
-        });
+        Log.logMessage("Starting React Native Packager.");
+        return this.remoteExtension.startPackager();
     }
 
     public prewarmBundleCache(): Q.Promise<void> {

--- a/src/common/packager.ts
+++ b/src/common/packager.ts
@@ -51,6 +51,10 @@ export class Packager {
         return Packager.getHostForPort(this.port);
     }
 
+    public getRunningAs(): PackagerRunAs {
+        return this.packagerRunningAs;
+    }
+
     public startAsReactNative(port: number): Q.Promise<void> {
         return this.start(port, PackagerRunAs.REACT_NATIVE);
     }


### PR DESCRIPTION
If the packager is started from the command palette, and then the debugger is started, kill the first packager. VSCode controls that packager too, and it would be much less confusing.

* Moved packager type check logic (which prevents packager restart) from generalMobilePlatform to extensionServer
* Indicate when packager is actually stopped to prevent possible incorrect Status Bar state in case of an internal error
* Expose Packager PackagerRunAs property
* Updated exponentPlatform.startPackager log message to not to be confused with React Native packager
* Adds missing return promise in configureExponentEnvironment chain