### PR TITLE
Enable intellisense for React namespace

### DIFF
--- a/src/extension/tsconfigHelper.ts
+++ b/src/extension/tsconfigHelper.ts
@@ -25,10 +25,11 @@ export class TsConfigHelper {
                     const defaultTsConfig = {
                         compilerOptions: {
                             allowJs: true,
+                            allowSyntheticDefaultImports: true,
                         },
                         exclude: ["node_modules"],
                     };
-                    return fileSystem.writeFile(tsConfigPath, JSON.stringify(defaultTsConfig));
+                    return fileSystem.writeFile(tsConfigPath, JSON.stringify(defaultTsConfig, null, 4));
                 }
             });
     }


### PR DESCRIPTION
Enable `allowSyntheticDefaultImports` option by default for new projects to enable intellisense for React typings when the whole React namespace is being imported using `import React from 'react'` syntax.

This fixes #322