### PR TITLE
Exposed verbose logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,19 @@ To use a different `Typescript TSDK` version than the one that comes with vscode
 }
 ```
 
+To expose internal logs to the output, set the following properties:
+
+```
+{
+  "react-native-tools": {
+    "showInternalLogs": true,
+    "logLevel": "Trace"
+  }
+}
+```
+
+`logLevel` can be `None` (no logs), `Error`, `Warning`, `Info`, `Debug`, `Trace` (all logs). Default is `None`.
+
 ## Using Exponentjs
 
 We support using exponentjs to run, debug and publish your applications. For more information on exponent, see [here](https://docs.getexponent.com/).

--- a/src/common/log/logHelper.ts
+++ b/src/common/log/logHelper.ts
@@ -5,6 +5,7 @@
  * Helper for the log utility.
  */
 
+import {workspace} from "vscode";
 import * as util from "util";
 import {InternalError, InternalErrorLevel} from "../error/internalError";
 
@@ -25,6 +26,15 @@ export class LogHelper {
     public static WARN_TAG: string = "[Warning]";
     private static ERROR_CODE_WIDTH: string = "0000";
     private static LOG_LEVEL_NAME: string = "RN_LOG_LEVEL";
+
+    public static get showInternal(): boolean {
+        let rntConf = workspace.getConfiguration("react-native-tools");
+
+        if (rntConf) {
+            return rntConf.get<boolean>("showInternalLogs");
+        }
+        return false;
+    }
 
     public static get logLevel(): LogLevel {
         let valName: string = process.env[LogHelper.LOG_LEVEL_NAME];

--- a/src/extension/outputChannelLogger.ts
+++ b/src/extension/outputChannelLogger.ts
@@ -56,6 +56,10 @@ export class OutputChannelLogger implements ILogger {
     }
 
     public logInternalMessage(logLevel: LogLevel, message: string) {
+        if (LogHelper.showInternal) {
+            this.logMessage(this.getFormattedInternalMessage(logLevel, message));
+            return;
+        }
         console.log(this.getFormattedInternalMessage(logLevel, message));
     }
 

--- a/src/extension/rn-extension.ts
+++ b/src/extension/rn-extension.ts
@@ -26,6 +26,7 @@ import {ErrorHelper} from "../common/error/errorHelper";
 import {InternalError} from "../common/error/internalError";
 import {InternalErrorCode} from "../common/error/internalErrorCode";
 import {Log} from "../common/log/log";
+import {LogLevel, LogHelper} from "../common/log/logHelper";
 import {PackagerStatusIndicator} from "./packagerStatusIndicator";
 import {ReactNativeProjectHelper} from "../common/reactNativeProjectHelper";
 import {ReactDirManager} from "./reactDirManager";
@@ -53,7 +54,7 @@ interface ISetupableDisposable extends vscode.Disposable {
 }
 
 export function activate(context: vscode.ExtensionContext): void {
-
+    configureLogLevel();
     entryPointHandler.runApp("react-native", () => <string>require("../../package.json").version,
         ErrorHelper.getInternalError(InternalErrorCode.ExtensionActivationFailed), projectRootPath, () => {
         return reactNativeProjectHelper.isReactNativeProject()
@@ -95,6 +96,13 @@ export function deactivate(): Q.Promise<void> {
                 });
             }, /*errorsAreFatal*/ true);
     });
+}
+
+function configureLogLevel(): void {
+    let rntConf = vscode.workspace.getConfiguration("react-native-tools");
+    let logLevelString: string = rntConf.get<string>("logLevel", "None");
+    let logLevel: LogLevel = <LogLevel>parseInt(LogLevel[<any>logLevelString], 10);
+    LogHelper.logLevel = logLevel;
 }
 
 function configureNodeDebuggerLocation(): Q.Promise<void> {


### PR DESCRIPTION
Users are reporting issues on GitHub that would be easier to debug if we exposed our verbose logging. The user could then copy the logs and send them to us to make it easier to debug issues they're having. We should expose a flag to enable verbose logging in our extension.