### PR TITLE
Expose logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,19 @@ To use a different `Typescript TSDK` version than the one that comes with vscode
 }
 ```
 
+To expose internal logs to the output, set the following properties:
+
+```
+{
+  "react-native-tools": {
+    "showInternalLogs": true,
+    "logLevel": "Trace"
+  }
+}
+```
+
+`logLevel` can be `None` (no logs), `Error`, `Warning`, `Info`, `Debug`, `Trace` (all logs). Default is `None`.
+
 ## Using Exponentjs
 
 We support using exponentjs to run, debug and publish your applications. For more information on exponent, see [here](https://docs.getexponent.com/).

--- a/src/extension/outputChannelLogger.ts
+++ b/src/extension/outputChannelLogger.ts
@@ -7,6 +7,7 @@
 
 import {ILogger} from "../common/log/loggers";
 import {LogHelper, LogLevel} from "../common/log/logHelper";
+import {SettingsHelper} from "./settingsHelper";
 import {OutputChannel} from "vscode";
 import * as vscode from "vscode";
 
@@ -56,6 +57,10 @@ export class OutputChannelLogger implements ILogger {
     }
 
     public logInternalMessage(logLevel: LogLevel, message: string) {
+        if (SettingsHelper.getShowInternalLogs()) {
+            this.logMessage(this.getFormattedInternalMessage(logLevel, message));
+            return;
+        }
         console.log(this.getFormattedInternalMessage(logLevel, message));
     }
 

--- a/src/extension/rn-extension.ts
+++ b/src/extension/rn-extension.ts
@@ -26,6 +26,8 @@ import {ErrorHelper} from "../common/error/errorHelper";
 import {InternalError} from "../common/error/internalError";
 import {InternalErrorCode} from "../common/error/internalErrorCode";
 import {Log} from "../common/log/log";
+import {LogHelper} from "../common/log/logHelper";
+import {SettingsHelper} from "./settingsHelper";
 import {PackagerStatusIndicator} from "./packagerStatusIndicator";
 import {ReactNativeProjectHelper} from "../common/reactNativeProjectHelper";
 import {ReactDirManager} from "./reactDirManager";
@@ -53,7 +55,7 @@ interface ISetupableDisposable extends vscode.Disposable {
 }
 
 export function activate(context: vscode.ExtensionContext): void {
-
+    configureLogLevel();
     entryPointHandler.runApp("react-native", () => <string>require("../../package.json").version,
         ErrorHelper.getInternalError(InternalErrorCode.ExtensionActivationFailed), projectRootPath, () => {
         return reactNativeProjectHelper.isReactNativeProject()
@@ -95,6 +97,10 @@ export function deactivate(): Q.Promise<void> {
                 });
             }, /*errorsAreFatal*/ true);
     });
+}
+
+function configureLogLevel(): void {
+    LogHelper.logLevel = SettingsHelper.getLogLevel();
 }
 
 function configureNodeDebuggerLocation(): Q.Promise<void> {

--- a/src/extension/settingsHelper.ts
+++ b/src/extension/settingsHelper.ts
@@ -5,6 +5,7 @@ import * as vscode from "vscode";
 import path = require("path");
 import {ConfigurationReader} from "../common/configurationReader";
 import {Packager} from "../common/packager";
+import {LogLevel} from "../common/log/logHelper";
 
 export class SettingsHelper {
 
@@ -52,5 +53,28 @@ export class SettingsHelper {
             return ConfigurationReader.readInt(workspaceConfiguration.get("react-native.packager.port"));
         }
         return Packager.DEFAULT_PORT;
+    }
+
+    /**
+     * Get showInternalLogs setting
+     */
+    public static getShowInternalLogs(): boolean {
+        const workspaceConfiguration = vscode.workspace.getConfiguration();
+        if (workspaceConfiguration.has("react-native-tools.showInternalLogs")) {
+            return ConfigurationReader.readBoolean(workspaceConfiguration.get("react-native-tools.showInternalLogs"));
+        }
+        return false;
+    }
+
+    /**
+     * Get logLevel setting
+     */
+    public static getLogLevel(): LogLevel {
+        const workspaceConfiguration = vscode.workspace.getConfiguration();
+        if (workspaceConfiguration.has("react-native-tools.logLevel")) {
+            let logLevelString: string = ConfigurationReader.readString(workspaceConfiguration.get("react-native-tools.logLevel"));
+            return <LogLevel>parseInt(LogLevel[<any>logLevelString], 10);
+        }
+        return LogLevel.None;
     }
 }


### PR DESCRIPTION
Users are reporting issues on GitHub that would be easier to debug if we exposed our verbose logging. The user could then copy the logs and send them to us to make it easier to debug issues they're having. We should expose a flag to enable verbose logging in our extension.