### PR TITLE
Improve source map URL regex to ignore inline maps

### DIFF
--- a/src/debugger/sourceMap.ts
+++ b/src/debugger/sourceMap.ts
@@ -20,7 +20,7 @@ interface ISourceMapSection {
 }
 
 export class SourceMapUtil {
-    private static SourceMapURLRegex: RegExp = /\/\/(#|@) sourceMappingURL=(.+?)\s*$/m;
+    private static SourceMapURLRegex: RegExp = /\/\/(#|@) sourceMappingURL=((?!data:).+?)\s*$/m;
 
     /**
      * Given a script body and URL, this method parses the body and finds the corresponding source map URL.

--- a/src/test/debugger/sourceMap.test.ts
+++ b/src/test/debugger/sourceMap.test.ts
@@ -27,9 +27,30 @@ suite("sourceMap", function() {
             assert.equal(expectedUrlHref, result.href);
         });
 
+        test("should ignore inline sourcemap urls", function () {
+            const scriptUrl: url.Url = url.parse("http://localhost:8081/index.ios.bundle?platform=ios&dev=true");
+            const scriptBody = "//# sourceMappingURL=data:application/json;base64,eyJmb28iOiJiYXIifQ==\n" +
+                               "//# sourceMappingURL=/index.ios.map?platform=ios&dev=true";
+            const expectedUrlHref = "http://localhost:8081/index.ios.map?platform=ios&dev=true";
+
+            const sourceMap = new SourceMapUtil();
+            const result = sourceMap.getSourceMapURL(scriptUrl, scriptBody);
+            assert.equal(expectedUrlHref, result.href);
+        });
+
         test("should return null for an invalid sourcemap url", function () {
             const scriptUrl: url.Url = url.parse("http://localhost:8081/index.ios.bundle?platform=ios&dev=true");
             const scriptBody = "";
+
+            const sourceMap = new SourceMapUtil();
+            const result = sourceMap.getSourceMapURL(scriptUrl, scriptBody);
+            assert(result === null);
+        });
+
+        test("should return null if there are only inline sourcemap urls", function () {
+            const scriptUrl: url.Url = url.parse("http://localhost:8081/index.ios.bundle?platform=ios&dev=true");
+            const scriptBody = "//# sourceMappingURL=data:application/json;base64,eyJmb28iOiJiYXIifQ==\n" +
+                               "//# sourceMappingURL=data:application/json;base64,eyJiYXoiOiJxdXV4In0=";
 
             const sourceMap = new SourceMapUtil();
             const result = sourceMap.getSourceMapURL(scriptUrl, scriptBody);


### PR DESCRIPTION
React-native packager produces an inline sourcemaps for each module in the bundle even if `.babelrc` has `sourceMaps: true`

This leads to debugging failure when we're trying to get sourcemap URL from the bundle and expect it to be a file URL, rather than data URL