### PR TITLE
Removing 'require' from appworker sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.5
+* Removed `require` from app worker context to work around change in node 7. `__debug__.require` is still present for applications which need it
+
 ## 0.2.4
 * Allowed using this extension in a workspace with the react-native project in a subfolder.
 * Ignore references to inline sourcemaps, in the hopes of finding another reference to a map file

--- a/src/debugger/appWorker.ts
+++ b/src/debugger/appWorker.ts
@@ -26,7 +26,6 @@ interface DebuggerWorkerSandbox {
     __dirname: string;
     self: DebuggerWorkerSandbox;
     console: typeof console;
-    require: (id: string) => any;
     importScripts: (url: string) => void;
     postMessage: (object: any) => void;
     onmessage: (object: RNAppMessage) => void;
@@ -135,7 +134,6 @@ export class SandboxedAppWorker {
             __dirname: path.dirname(scriptToRunPath),
             self: null,
             console: console,
-            require: (filePath: string) => scriptToRunModule.require(filePath), // Give the sandbox access to require("<filePath>");
             importScripts: (url: string) => this.importScripts(url), // Import script like using <script/>
             postMessage: (object: any) => this.gotResponseFromDebuggerWorker(object), // Post message back to the UI thread
             onmessage: null,


### PR DESCRIPTION
React-native does not expect that 'require' exists in the ambient context, and attempts to overwrite it with a require.js require. However, in node 7 this replacement fails, so we should simply not provide one in the first place so the require.js require is picked up.

Fixes #370 