### PR TITLE
Pass Android build variant to react-native

### DIFF
--- a/src/common/android/androidPlatform.ts
+++ b/src/common/android/androidPlatform.ts
@@ -24,13 +24,25 @@ export class AndroidPlatform extends GeneralMobilePlatform {
     private static MULTIPLE_DEVICES_ERROR = "error: more than one device/emulator";
 
     // We should add the common Android build/run erros we find to this list
-    private static RUN_ANDROID_FAILURE_PATTERNS: PatternToFailure = {
-        "Failed to install on any devices": "Could not install the app on any available device. Make sure you have a correctly"
-         + " configured device or emulator running. See https://facebook.github.io/react-native/docs/android-setup.html",
-    "com.android.ddmlib.ShellCommandUnresponsiveException": "An Android shell command timed-out. Please retry the operation.",
-    "Android project not found": "Android project not found.",
-    "error: more than one device/emulator": AndroidPlatform.MULTIPLE_DEVICES_ERROR,
-    };
+    private static RUN_ANDROID_FAILURE_PATTERNS: PatternToFailure[] = [{
+        pattern: "Failed to install on any devices",
+        message: "Could not install the app on any available device. Make sure you have a correctly"
+            + " configured device or emulator running. See https://facebook.github.io/react-native/docs/android-setup.html",
+    }, {
+        pattern: "com.android.ddmlib.ShellCommandUnresponsiveException",
+        message: "An Android shell command timed-out. Please retry the operation.",
+    }, {
+        pattern: "Android project not found",
+        message: "Android project not found.",
+
+    }, {
+        pattern: "error: more than one device/emulator",
+        message: AndroidPlatform.MULTIPLE_DEVICES_ERROR,
+    }, {
+        pattern: /^Error: Activity class \{.*\} does not exist\.$/m,
+        message: "Failed to launch the specified activity. Try running application manually and "
+            + "start debugging using 'Attach to packager' launch configuration.",
+    }];
 
     private static RUN_ANDROID_SUCCESS_PATTERNS: string[] = ["BUILD SUCCESSFUL", "Starting the app", "Starting: Intent"];
 

--- a/src/debugger/ios/iOSPlatform.ts
+++ b/src/debugger/ios/iOSPlatform.ts
@@ -29,10 +29,13 @@ export class IOSPlatform extends GeneralMobilePlatform {
     private iosProjectPath: string;
 
     // We should add the common iOS build/run erros we find to this list
-    private static RUN_IOS_FAILURE_PATTERNS: PatternToFailure = {
-        "No devices are booted": "Unable to launch iOS simulator. Try specifying a different target.",
-        "FBSOpenApplicationErrorDomain": "Unable to launch iOS simulator. Try specifying a different target.",
-    };
+    private static RUN_IOS_FAILURE_PATTERNS: PatternToFailure[] = [{
+        pattern: "No devices are booted",
+        message: "Unable to launch iOS simulator. Try specifying a different target.",
+    }, {
+        pattern: "FBSOpenApplicationErrorDomain",
+        message: "Unable to launch iOS simulator. Try specifying a different target.",
+    }];
 
     private static RUN_IOS_SUCCESS_PATTERNS = ["BUILD SUCCEEDED"];
 

--- a/src/debugger/nodeDebugAdapter.d.ts
+++ b/src/debugger/nodeDebugAdapter.d.ts
@@ -40,6 +40,7 @@ interface ILaunchRequestArgs {
     args: string[];
     logCatArguments: any;
     program: string;
+    variant?: string;
 }
 
 interface IAttachRequestArgs {

--- a/src/debugger/nodeDebugWrapper.ts
+++ b/src/debugger/nodeDebugWrapper.ts
@@ -74,6 +74,10 @@ export class NodeDebugWrapper {
                 nodeDebugWrapper.mobilePlatformOptions.logCatArguments = [nodeDebugWrapper.parseLogCatArguments(args.logCatArguments)];
             }
 
+            if (!nodeDebugWrapper.isNullOrUndefined(args.variant)) {
+                nodeDebugWrapper.mobilePlatformOptions.variant = args.variant;
+            }
+
             return TelemetryHelper.generate("launch", (generator) => {
                 const resolver = new PlatformResolver();
                 return nodeDebugWrapper.remoteExtension.getPackagerPort()


### PR DESCRIPTION
This PR adds `"variant"` option to launch config, that complies with `--variant` option for `react-native run-android` command.

Also for the cases when `react-native run-android` is not able to run the app on device/simulator it adds a descriptive error message. This is needed as react-native does not yet support launching apps with application Id other than specified in Android manifest (see https://github.com/facebook/react-native/issues/8308)