### PR TITLE
Fix regressions in app worker introduced after moving to 'node2' debugger

### DIFF
--- a/src/debugger/appWorker.ts
+++ b/src/debugger/appWorker.ts
@@ -39,10 +39,16 @@ function printDebuggingError(message: string, reason: any) {
 export class MultipleLifetimesAppWorker extends EventEmitter {
     public static WORKER_BOOTSTRAP = `
 // Initialize some variables before react-native code would access them
-// and also avoid Node's GLOBAL deprecation warning
-var onmessage=null, self=global.GLOBAL=global;
+var onmessage=null, self=global;
 // Cache Node's original require as __debug__.require
 var __debug__={require: require};
+// avoid Node's GLOBAL deprecation warning
+Object.defineProperty(global, "GLOBAL", {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value: global
+});
 process.on("message", function(message){
     if (onmessage) onmessage(message);
 });

--- a/src/debugger/appWorker.ts
+++ b/src/debugger/appWorker.ts
@@ -41,7 +41,7 @@ export class MultipleLifetimesAppWorker extends EventEmitter {
 // Initialize some variables before react-native code would access them
 var onmessage=null, self=global;
 // Cache Node's original require as __debug__.require
-var __debug__={require: require};
+global.__debug__={require: require};
 // avoid Node's GLOBAL deprecation warning
 Object.defineProperty(global, "GLOBAL", {
     configurable: true,

--- a/src/test/debugger/appWorker.test.ts
+++ b/src/test/debugger/appWorker.test.ts
@@ -68,7 +68,7 @@ suite("appWorker", function() {
                 return workerWithScript(startScriptContents).start().then(() => {
                     // We have not yet finished importing the script, we should not have posted a response yet
                     assert(postReplyFunction.notCalled, "postReplyFuncton called before scripts imported");
-                    return Q.delay(100);
+                    return Q.delay(500);
                 }).then(() => {
                     assert(postReplyFunction.calledWith("postImport"), "postMessage after import not handled");
                     assert(postReplyFunction.calledWith("inImport"), "postMessage not registered from within import");


### PR DESCRIPTION
This PR fixes the following 2 issues:
- Node's `'GLOBAL' deprecation warning` caused by accessing `global.GLOBAL` property
- Missing `global.__debug__.require` which is intended to hold original Node's `require`

This should fix #398 and #406 