### PR TITLE
Avoid unhandled rejections when breakpoints are being set up unsuccessfully

### DIFF
--- a/src/debugger/nodeDebugAdapter.d.ts
+++ b/src/debugger/nodeDebugAdapter.d.ts
@@ -50,8 +50,42 @@ declare module ChromeDebuggerCorePackage {
 }
 
 declare module Node2DebugAdapterPackage {
+
+    type ChecksumAlgorithm = "MD5" | "SHA1" | "SHA256" | "timestamp";
+
+    interface Checksum {
+        algorithm: ChecksumAlgorithm;
+        checksum: string;
+    }
+
+    interface Source {
+        name?: string;
+        path?: string;
+        sourceReference?: number;
+        presentationHint?: "emphasize" | "deemphasize";
+        origin?: string;
+        adapterData?: any;
+        checksums?: Checksum[];
+    }
+
+    interface Breakpoint {
+        id?: number;
+        verified: boolean;
+        message?: string;
+        source?: Source;
+        line?: number;
+        column?: number;
+        endLine?: number;
+        endColumn?: number;
+    }
+
+    interface ISetBreakpointsResponseBody {
+        breakpoints: Breakpoint[];
+    }
+
     class Node2DebugAdapter extends ChromeDebuggerCorePackage.ChromeDebugAdapter {
         protected doAttach(port: number, targetUrl?: string, address?: string, timeout?: number): Promise<void>;
+        public setBreakpoints(args: any, requestSeq: number, ids?: number[]): Promise<ISetBreakpointsResponseBody>;
     }
 }
 

--- a/src/debugger/nodeDebugWrapper.ts
+++ b/src/debugger/nodeDebugWrapper.ts
@@ -16,6 +16,7 @@ import {TargetPlatformHelper} from "../common/targetPlatformHelper";
 import {ExtensionTelemetryReporter, ReassignableTelemetryReporter} from "../common/telemetryReporters";
 import {NodeDebugAdapterLogger} from "../common/log/loggers";
 import {Log} from "../common/log/log";
+import {LogLevel} from "../common/log/logHelper";
 import {GeneralMobilePlatform} from "../common/generalMobilePlatform";
 
 import { MultipleLifetimesAppWorker } from "./appWorker";
@@ -211,6 +212,17 @@ export function makeAdapter(debugAdapterClass: typeof Node2DebugAdapterPackage.N
             // to set up breakpoints on initial pause event
             this._attachMode = false;
             return super.doAttach(port, targetUrl, address, timeout);
+        }
+
+        public setBreakpoints(args: any, requestSeq: number, ids?: number[]): Promise<Node2DebugAdapterPackage.ISetBreakpointsResponseBody> {
+            // We need to overwrite ChromeDebug's setBreakpoints to get rid unhandled rejections
+            // when breakpoints are being set up unsuccessfully
+            return super.setBreakpoints(args, requestSeq, ids).catch((err) => {
+                Log.logInternalMessage(LogLevel.Error, err.message);
+                return {
+                    breakpoints: [],
+                };
+            });
         }
     };
 }


### PR DESCRIPTION
Could not reproduce this issue https://github.com/Microsoft/vscode-react-native/issues/399, but there is a way to catch unhandled exception by overwriting `setBreakpoints` method that passes on empty breakpoints array in case of failure.