### PR TITLE
Fix bug with loading assets in exponent and upgrade XDL

### DIFF
--- a/src/common/exponent/exponentHelper.ts
+++ b/src/common/exponent/exponentHelper.ts
@@ -105,6 +105,11 @@ export class ExponentHelper {
             });
     }
 
+    public getExponentPackagerOptions(): Q.Promise<any> {
+        this.lazilyInitialize();
+        return this.readFromExpJson<string>("packagerOpts");
+    }
+
     /**
      * File used as an entrypoint for exponent. This file's component should be registered as "main"
      * in the AppRegistry and should only render a entrypoint component.

--- a/src/common/exponent/xdlInterface.ts
+++ b/src/common/exponent/xdlInterface.ts
@@ -9,7 +9,7 @@ import * as XDLPackage from "xdl";
 import * as path from "path";
 import * as Q from "q";
 
-const XDL_VERSION = "0.20.0";
+const XDL_VERSION = "32.0.0";
 let xdlPackage: Q.Promise<typeof XDLPackage>;
 
 function getPackage(): Q.Promise<typeof XDLPackage> {


### PR DESCRIPTION
Couldn't resolve asset's modules in exponent apps due to we haven't passed packager options from `exp.json` to react-native packager.
Related issues: https://github.com/Microsoft/vscode-react-native/issues/414, https://github.com/Microsoft/vscode-react-native/issues/407