### PR TITLE
Prefer xcworkspace over xcodeproj when launching xcodebuild.

### DIFF
--- a/src/common/ios/xcodeproj.ts
+++ b/src/common/ios/xcodeproj.ts
@@ -25,17 +25,23 @@ export class Xcodeproj {
         return this.nodeFileSystem
             .readDir(projectRoot)
             .then((files: string[]): IXcodeProjFile => {
+                const extensions = [".xcworkspace", ".xcodeproj"];
                 const sorted = files.sort();
-                const candidate = sorted.find((file: string) =>
-                    [".xcodeproj", ".xcworkspace"].indexOf(path.extname(file)) !== -1
+                const candidates = sorted.filter((file: string) =>
+                    extensions.indexOf(path.extname(file)) !== -1
+                ).sort((a, b) =>
+                    extensions.indexOf(path.extname(a)) - extensions.indexOf(path.extname(b))
                 );
-                if (!candidate) {
+
+                if (candidates.length === 0) {
                     throw new Error("Unable to find any xcodeproj or xcworkspace files.");
                 }
 
-                const fileName = path.join(projectRoot, candidate);
-                const fileType = path.extname(candidate);
-                const projectName = path.basename(candidate, fileType);
+                const bestCandidate = candidates[0];
+
+                const fileName = path.join(projectRoot, bestCandidate);
+                const fileType = path.extname(bestCandidate);
+                const projectName = path.basename(bestCandidate, fileType);
                 return {
                     fileName,
                     fileType,

--- a/src/test/common/ios/xcodeproj.test.ts
+++ b/src/test/common/ios/xcodeproj.test.ts
@@ -31,5 +31,30 @@ suite("xcodeproj", function() {
                     });
                 });
         });
+        test("should look in the correct location for xcodeproj/xcworkspace files and prefer xcworkspace over xcodeproj", function() {
+            const projectRoot = path.join("/", "tmp", "myProject");
+            const projectName = "foo";
+            const xcodeprojFileType = ".xcodeproj";
+            const xcworkspaceFileType = ".xcworkspace";
+            const xcodeprojFileName = projectName + xcodeprojFileType;
+            const xcworkspaceFileName = projectName + xcworkspaceFileType;
+            const testFiles = [xcodeprojFileName, xcworkspaceFileName];
+            const mockFileSystem: any = {
+                readDir: (path: string) => {
+                    return Q(testFiles);
+                },
+            };
+
+            const xcodeproj = new Xcodeproj({ nodeFileSystem: mockFileSystem });
+
+            return xcodeproj.findXcodeprojFile(projectRoot)
+                .then((proj) => {
+                    assert.deepEqual(proj, {
+                        fileName: path.join(projectRoot, xcworkspaceFileName),
+                        fileType: xcworkspaceFileType,
+                        projectName,
+                    });
+                });
+        });
     });
 });


### PR DESCRIPTION
I modified Xcode project/workspace file detection to prefer workspaces over project files (this is more consistent with the way react-native's cli tools work). 

This also plays nicely with CocoaPods when the workspace and app project file are in the same directory.

For reference: https://github.com/facebook/react-native/blob/9ee815f6b52e0c2417c04e5a05e1e31df26daed2/local-cli/runIOS/__tests__/findXcodeProject-test.js#L31