### PR TITLE
Implement logic for displaying Expo's QR code

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/Microsoft/vscode-react-native"
   },
   "engines": {
-    "vscode": "^0.10.1"
+    "vscode": "^0.10.8"
   },
   "categories": [
     "Debuggers",
@@ -250,6 +250,7 @@
     "flatten-source-map": "0.0.2",
     "options": "0.0.6",
     "q": "1.4.1",
+    "qr-image": "^3.2.0",
     "semver": "5.1.0",
     "strip-json-comments": "2.0.1",
     "typechecker": "2.0.8",

--- a/src/common/exponent/exponentPlatform.ts
+++ b/src/common/exponent/exponentPlatform.ts
@@ -20,7 +20,6 @@ export class ExponentPlatform extends GeneralMobilePlatform {
     public runApp(): Q.Promise<void> {
         const outputMessage = `Application is running on Exponent. Open your exponent app at ${this.exponentTunnelPath} to see it.`;
         Log.logMessage(outputMessage);
-        this.remoteExtension.showInformationMessage(outputMessage);
         return Q.resolve<void>(void 0);
     }
 

--- a/src/extension/commandPaletteHandler.ts
+++ b/src/extension/commandPaletteHandler.ts
@@ -133,7 +133,7 @@ export class CommandPaletteHandler {
                     Log.logMessage("Application is running on Exponent.");
                     const exponentOutput = `Open your exponent app at ${exponentUrl}`;
                     Log.logMessage(exponentOutput);
-                    vscode.window.showInformationMessage(exponentOutput);
+                    vscode.commands.executeCommand("vscode.previewHtml", vscode.Uri.parse(exponentUrl), 1, "Expo QR code");
                 });
         }
         return this.reactNativePackager.startAsReactNative(SettingsHelper.getPackagerPort())

--- a/src/extension/extensionServer.ts
+++ b/src/extension/extensionServer.ts
@@ -128,19 +128,20 @@ export class ExtensionServer implements vscode.Disposable {
             }
         }).then(() =>
             this.exponentHelper.configureExponentEnvironment()
-        ).then(() =>
-            this.exponentHelper.loginToExponent(
-                (message, password) => { return Q(vscode.window.showInputBox({ placeHolder: message, password: password })); },
-                (message) => { return Q(vscode.window.showInformationMessage(message)); }
-            ))
-        .then(() => {
-            const portToUse = ConfigurationReader.readIntWithDefaultSync(port, SettingsHelper.getPackagerPort());
-            return this.reactNativePackager.startAsExponent(portToUse);
-        })
-        .then(exponentUrl => {
-            this.reactNativePackageStatusIndicator.updatePackagerStatus(PackagerStatus.EXPONENT_PACKAGER_STARTED);
-            return exponentUrl;
-        });
+            ).then(() =>
+                this.exponentHelper.loginToExponent(
+                    (message, password) => { return Q(vscode.window.showInputBox({ placeHolder: message, password: password })); },
+                    (message) => { return Q(vscode.window.showInformationMessage(message)); }
+                ))
+            .then(() => {
+                const portToUse = ConfigurationReader.readIntWithDefaultSync(port, SettingsHelper.getPackagerPort());
+                return this.reactNativePackager.startAsExponent(portToUse);
+            })
+            .then(exponentUrl => {
+                vscode.commands.executeCommand("vscode.previewHtml", vscode.Uri.parse(exponentUrl), 1, "Expo QR code");
+                this.reactNativePackageStatusIndicator.updatePackagerStatus(PackagerStatus.EXPONENT_PACKAGER_STARTED);
+                return exponentUrl;
+            });
     }
 
     /**

--- a/src/extension/qrCodeContentProvider.ts
+++ b/src/extension/qrCodeContentProvider.ts
@@ -1,0 +1,31 @@
+import * as qr from "qr-image";
+import { TextDocumentContentProvider, Uri, CancellationToken } from "vscode";
+
+export class QRCodeContentProvider implements TextDocumentContentProvider {
+
+    private cache: { [uri: string]: string } = {};
+
+    public provideTextDocumentContent(uri: Uri, token: CancellationToken): string {
+
+        let stringUri = uri.toString();
+
+        if (!this.cache[stringUri]) {
+            const imageBuffer: NodeBuffer = qr.imageSync(stringUri);
+            this.cache[stringUri] = "data:image/png;base64," + imageBuffer.toString("base64");
+        }
+
+        return `<!DOCTYPE html>
+        <html>
+        <body>
+            <div style="text-align:center">
+                <h3>
+                    Expo is running. Open your Expo app at<br/>
+                    <span style="text-decoration: underline">${stringUri}</span><br/>
+                    or scan QR code below:
+                <h3>
+                <img src="${this.cache[stringUri]}" />
+            </div>
+        </body>
+        </html>`;
+    }
+}

--- a/src/extension/qrCodeContentProvider.ts
+++ b/src/extension/qrCodeContentProvider.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
 import * as qr from "qr-image";
 import { TextDocumentContentProvider, Uri, CancellationToken } from "vscode";
 

--- a/src/extension/rn-extension.ts
+++ b/src/extension/rn-extension.ts
@@ -36,7 +36,8 @@ import {Telemetry} from "../common/telemetry";
 import {TelemetryHelper} from "../common/telemetryHelper";
 import {ExtensionServer} from "./extensionServer";
 import {DelayedOutputChannelLogger} from "./outputChannelLogger";
-import {ExponentHelper} from "../common/exponent/exponentHelper";
+import { ExponentHelper } from "../common/exponent/exponentHelper";
+import { QRCodeContentProvider } from "./qrCodeContentProvider";
 
 /* all components use the same packager instance */
 const projectRootPath = SettingsHelper.getReactNativeProjectRoot();
@@ -80,7 +81,10 @@ export function activate(context: vscode.ExtensionContext): void {
                     ErrorHelper.getInternalError(InternalErrorCode.NodeDebuggerConfigurationFailed), () => {
                         configureNodeDebuggerLocation();
                     });
+
                 registerReactNativeCommands(context);
+                context.subscriptions.push(vscode.workspace
+                    .registerTextDocumentContentProvider("exp", new QRCodeContentProvider()));
             });
     });
 }


### PR DESCRIPTION
This PR adds functionality that shows QR code with URL of Expo app when Expo packager starts, so the app could be opened by scanning that code.

See screenshot below for the example of how it'll look like

![screen shot 2017-03-30 at 16 22 47](https://cloud.githubusercontent.com/assets/3857604/24506381/f923c8fc-1565-11e7-9c0d-1b0a10cb0889.png)

This implements #423 