### PR TITLE
allow “scheme” to be defined and passed through to xcodebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -231,6 +231,10 @@
               "variant": {
                 "type": "string",
                 "description": "A variant to be passed to react-native run-android, e.g. 'devDebug' to specify --variant=devDebug"
+              },
+              "scheme": {
+                "type": "string",
+                "description": "A scheme name to be passed to react-native run-ios, e.g. 'devDebug' to specify --scheme=devDebug"
               }
             }
           }

--- a/src/common/launchArgs.ts
+++ b/src/common/launchArgs.ts
@@ -8,6 +8,7 @@ export interface IRunOptions extends ILaunchArgs {
     projectRoot: string;
     iosRelativeProjectPath?: string;
     variant?: string;
+    scheme?: string;
 }
 
 /**

--- a/src/debugger/ios/compiler.ts
+++ b/src/debugger/ios/compiler.ts
@@ -6,11 +6,14 @@ import * as Q from "q";
 
 import {CommandExecutor} from "../../common/commandExecutor";
 import {Xcodeproj, IXcodeProjFile} from "../../common/ios/xcodeproj";
+import {IRunOptions} from "../../common/launchArgs";
 
 export class Compiler {
     private projectRoot: string;
+    private runOptions: IRunOptions;
 
-    constructor(projectRoot: string) {
+    constructor(runOptions: IRunOptions, projectRoot: string) {
+        this.runOptions = runOptions;
         this.projectRoot = projectRoot;
     }
 
@@ -27,7 +30,7 @@ export class Compiler {
         return new Xcodeproj().findXcodeprojFile(this.projectRoot).then((projectFile: IXcodeProjFile) => {
             return [
                 projectFile.fileType === ".xcworkspace" ? "-workspace" : "-project", projectFile.fileName,
-                "-scheme", projectFile.projectName,
+                "-scheme", this.runOptions.scheme ? this.runOptions.scheme : projectFile.projectName,
                 "-destination", "generic/platform=iOS", // Build for a generic iOS device
                 "-derivedDataPath", path.join(this.projectRoot, "build"),
             ];

--- a/src/debugger/ios/iOSPlatform.ts
+++ b/src/debugger/ios/iOSPlatform.ts
@@ -58,6 +58,11 @@ export class IOSPlatform extends GeneralMobilePlatform {
 
             runArguments.push("--project-path", this.runOptions.iosRelativeProjectPath);
 
+            // provide any defined scheme
+            if (this.runOptions.scheme) {
+                runArguments.push("--scheme", this.runOptions.scheme);
+            }
+
             const runIosSpawn = new CommandExecutor(this.projectPath).spawnReactCommand("run-ios", runArguments);
             return new OutputVerifier(
                 () =>
@@ -66,7 +71,7 @@ export class IOSPlatform extends GeneralMobilePlatform {
                     Q(IOSPlatform.RUN_IOS_FAILURE_PATTERNS)).process(runIosSpawn);
         }
 
-        return new Compiler(this.iosProjectPath).compile().then(() => {
+        return new Compiler(this.runOptions, this.iosProjectPath).compile().then(() => {
             return new DeviceDeployer(this.iosProjectPath).deploy();
         }).then(() => {
             return new DeviceRunner(this.iosProjectPath).run();

--- a/src/debugger/nodeDebugWrapper.ts
+++ b/src/debugger/nodeDebugWrapper.ts
@@ -79,6 +79,10 @@ export function makeSession(debugSessionClass: typeof ChromeDebuggerCorePackage.
                 this.mobilePlatformOptions.variant = request.arguments.variant;
             }
 
+            if (!isNullOrUndefined(request.arguments.scheme)) {
+                this.mobilePlatformOptions.scheme = request.arguments.scheme;
+            }
+
             TelemetryHelper.generate("launch", (generator) => {
                 return this.remoteExtension.getPackagerPort()
                 .then((packagerPort: number) => {


### PR DESCRIPTION
This PR addresses the issue https://github.com/Microsoft/vscode-react-native/issues/434

Per the noted issue, non trivial Xcode projects often define customized "schemes" and it is desirable to be able to specify them when building. 

I extended the "launch" configuration attributes to include an optional "scheme" property.  While I considered overloading the Android-centric "variant" property, in the end I believe providing a term-specific property is more clear to the user.

If this "scheme" property is provided in a launch.json configuration, its value is passed through to the `react-native run-ios` command in the simulator case, or to `xcodebuild` otherwise.   I tested both cases.

I did not explicitly create a test for this but I'd be happy for guidance on how this would work.  I reviewed previous similar feature adds ("variant") and didn't see specific tests in place.