### PR TITLE
add variant support for ReactNative.RunAndroid

### DIFF
--- a/src/extension/commandPaletteHandler.ts
+++ b/src/extension/commandPaletteHandler.ts
@@ -97,7 +97,8 @@ export class CommandPaletteHandler {
         TargetPlatformHelper.checkTargetPlatformSupport("android");
         return this.executeCommandInContext("runAndroid", () => this.executeWithPackagerRunning(() => {
             const packagerPort = SettingsHelper.getPackagerPort();
-            return new AndroidPlatform({ projectRoot: this.workspaceRoot, packagerPort: packagerPort }).runApp(/*shouldLaunchInAllDevices*/true);
+            const variant = SettingsHelper.getVariant();
+            return new AndroidPlatform({ projectRoot: this.workspaceRoot, packagerPort: packagerPort, variant: variant }).runApp(/*shouldLaunchInAllDevices*/true);
         }));
     }
 

--- a/src/extension/settingsHelper.ts
+++ b/src/extension/settingsHelper.ts
@@ -54,7 +54,16 @@ export class SettingsHelper {
         }
         return Packager.DEFAULT_PORT;
     }
-
+    /**
+     * Get android variant for React-Native.RunAndroid
+     */
+    public static getVariant() {
+        const workspaceConfiguration = vscode.workspace.getConfiguration();
+        if (workspaceConfiguration.has("react-native.variant")) {
+            return ConfigurationReader.readString(workspaceConfiguration.get("react-native.variant"));
+        }
+        return null;
+    }
     /**
      * Get showInternalLogs setting
      */


### PR DESCRIPTION
This adds variant support when running Run Android from command plate. This is not the same as https://github.com/Microsoft/vscode-react-native/pull/385 which supports variant when running through the debug command.