### PR TITLE
Fix check-copyright gulp task. Stick with tsc version 2.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -284,7 +284,7 @@
     "source-map-support": "^0.4.0",
     "through2": "^2.0.1",
     "tslint": "^3.6.0",
-    "typescript": "^2.2.1",
+    "typescript": "2.2.2",
     "vsce": "^1.3.0",
     "vscode": "^1.1.0"
   },


### PR DESCRIPTION
TSC 2.3 has [bug](https://github.com/Microsoft/TypeScript/issues/15819) which generate `use strict` in top of all comments. I suggest stick with typescript@2.2.2 until they will not fix it