### PR TITLE
Fix gulp-sourcemap generator

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -51,9 +51,7 @@ gulp.task("build", ["check-imports", "check-copyright"], function (callback) {
         })
         .pipe(sourcemaps.write(".", {
             includeContent: false,
-            sourceRoot: function (file) {
-                return path.relative(path.dirname(path.dirname(file.path)), __dirname + "/src");
-            }
+            sourceRoot: "."
         }))
         .pipe(gulp.dest(outPath));
 });


### PR DESCRIPTION
This fix allow set breakpoints in TS files (extension and debugger)