### PR TITLE
Fix "Error processing 'continue'"

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,6 +26,22 @@
             "preLaunchTask": "quick-build"
         },
         {
+            "name": "Quick Debug Debugger",
+            "type": "node",
+            "request": "launch",
+            "program": "${workspaceRoot}/src/debugger/reactNativeDebugEntryPoint.ts",
+            "runtimeArgs": [
+                "--harmony"
+            ],
+            "stopOnEntry": false,
+            "args": [
+                "--server=4712"
+            ], // Use "debugServer": "4712", on launch.json of the instance to debug
+            "sourceMaps": true,
+            "outDir": "${workspaceRoot}/out",
+            "preLaunchTask": "quick-build"
+        },
+        {
             "name": "Debug Debugger",
             "type": "node",
             "request": "launch",
@@ -131,6 +147,15 @@
             },
             "sourceMaps": true,
             "outDir": "${workspaceRoot}/out"
+        }
+    ],
+    "compounds": [
+        {
+            "name": "Quick Extension + Debugger",
+            "configurations": [
+                "Quick Launch Extension",
+                "Quick Debug Debugger"
+            ]
         }
     ]
 }

--- a/src/debugger/nodeDebugAdapter.d.ts
+++ b/src/debugger/nodeDebugAdapter.d.ts
@@ -24,6 +24,14 @@ declare module VSCodeDebugAdapterPackage {
         public event: string;
         public body: any;
     }
+    class ContinuedEvent extends Event {
+        public seq: number;
+        /** Must be 'event'. */
+        public type: string;
+        public body: {
+            threadId: number;
+        };
+    }
     interface Request {
         command: string;
         arguments?: any;

--- a/src/debugger/nodeDebugWrapper.ts
+++ b/src/debugger/nodeDebugWrapper.ts
@@ -6,26 +6,27 @@ import * as path from "path";
 import * as fs from "fs";
 import stripJsonComments = require("strip-json-comments");
 
-import {Telemetry} from "../common/telemetry";
-import {TelemetryHelper} from "../common/telemetryHelper";
-import {RemoteExtension} from "../common/remoteExtension";
-import {IOSPlatform} from "./ios/iOSPlatform";
-import {PlatformResolver} from "./platformResolver";
-import {IRunOptions} from "../common/launchArgs";
-import {TargetPlatformHelper} from "../common/targetPlatformHelper";
-import {ExtensionTelemetryReporter, ReassignableTelemetryReporter} from "../common/telemetryReporters";
-import {NodeDebugAdapterLogger} from "../common/log/loggers";
-import {Log} from "../common/log/log";
-import {LogLevel} from "../common/log/logHelper";
-import {GeneralMobilePlatform} from "../common/generalMobilePlatform";
+import { Telemetry } from "../common/telemetry";
+import { TelemetryHelper } from "../common/telemetryHelper";
+import { RemoteExtension } from "../common/remoteExtension";
+import { IOSPlatform } from "./ios/iOSPlatform";
+import { PlatformResolver } from "./platformResolver";
+import { IRunOptions } from "../common/launchArgs";
+import { TargetPlatformHelper } from "../common/targetPlatformHelper";
+import { ExtensionTelemetryReporter, ReassignableTelemetryReporter } from "../common/telemetryReporters";
+import { NodeDebugAdapterLogger } from "../common/log/loggers";
+import { Log } from "../common/log/log";
+import { LogLevel } from "../common/log/logHelper";
+import { GeneralMobilePlatform } from "../common/generalMobilePlatform";
 
 import { MultipleLifetimesAppWorker } from "./appWorker";
 
-export function makeSession(debugSessionClass: typeof ChromeDebuggerCorePackage.ChromeDebugSession,
-                            debugSessionOpts: ChromeDebuggerCorePackage.IChromeDebugSessionOpts,
-                            debugAdapterPackage: typeof VSCodeDebugAdapterPackage,
-                            telemetryReporter: ReassignableTelemetryReporter,
-                            appName: string, version: string): typeof ChromeDebuggerCorePackage.ChromeDebugSession {
+export function makeSession(
+    debugSessionClass: typeof ChromeDebuggerCorePackage.ChromeDebugSession,
+    debugSessionOpts: ChromeDebuggerCorePackage.IChromeDebugSessionOpts,
+    debugAdapterPackage: typeof VSCodeDebugAdapterPackage,
+    telemetryReporter: ReassignableTelemetryReporter,
+    appName: string, version: string): typeof ChromeDebuggerCorePackage.ChromeDebugSession {
 
     return class extends debugSessionClass {
 
@@ -43,7 +44,20 @@ export function makeSession(debugSessionClass: typeof ChromeDebuggerCorePackage.
             // Do not send "terminated" events signaling about session's restart to client as it would cause it
             // to restart adapter's process, while we want to stay alive and don't want to interrupt connection
             // to packager.
+
             if (event.event === "terminated" && event.body && event.body.restart === true) {
+
+                // Worker has been reloaded and switched to "continue" state
+                // So we have to send "continued" event to client instead of "terminated"
+                // Otherwise client might mistakenly show "stopped" state
+                let continuedEvent: VSCodeDebugAdapterPackage.ContinuedEvent = {
+                    event: "continued",
+                    type: "event",
+                    seq: event["seq"], // tslint:disable-line
+                    body: { threadId: event.body.threadId },
+                };
+
+                super.sendEvent(continuedEvent);
                 return;
             }
 
@@ -85,32 +99,32 @@ export function makeSession(debugSessionClass: typeof ChromeDebuggerCorePackage.
 
             TelemetryHelper.generate("launch", (generator) => {
                 return this.remoteExtension.getPackagerPort()
-                .then((packagerPort: number) => {
-                    this.mobilePlatformOptions.packagerPort = packagerPort;
-                    const mobilePlatform = new PlatformResolver()
-                        .resolveMobilePlatform(request.arguments.platform, this.mobilePlatformOptions);
+                    .then((packagerPort: number) => {
+                        this.mobilePlatformOptions.packagerPort = packagerPort;
+                        const mobilePlatform = new PlatformResolver()
+                            .resolveMobilePlatform(request.arguments.platform, this.mobilePlatformOptions);
 
-                    generator.step("checkPlatformCompatibility");
-                    TargetPlatformHelper.checkTargetPlatformSupport(this.mobilePlatformOptions.platform);
-                    generator.step("startPackager");
-                    return mobilePlatform.startPackager()
-                    .then(() => {
-                        // We've seen that if we don't prewarm the bundle cache, the app fails on the first attempt to connect to the debugger logic
-                        // and the user needs to Reload JS manually. We prewarm it to prevent that issue
-                        generator.step("prewarmBundleCache");
-                        Log.logMessage("Prewarming bundle cache. This may take a while ...");
-                        return mobilePlatform.prewarmBundleCache();
+                        generator.step("checkPlatformCompatibility");
+                        TargetPlatformHelper.checkTargetPlatformSupport(this.mobilePlatformOptions.platform);
+                        generator.step("startPackager");
+                        return mobilePlatform.startPackager()
+                            .then(() => {
+                                // We've seen that if we don't prewarm the bundle cache, the app fails on the first attempt to connect to the debugger logic
+                                // and the user needs to Reload JS manually. We prewarm it to prevent that issue
+                                generator.step("prewarmBundleCache");
+                                Log.logMessage("Prewarming bundle cache. This may take a while ...");
+                                return mobilePlatform.prewarmBundleCache();
+                            })
+                            .then(() => {
+                                generator.step("mobilePlatform.runApp");
+                                Log.logMessage("Building and running application.");
+                                return mobilePlatform.runApp();
+                            })
+                            .then(() => {
+                                return this.attachRequest(request, packagerPort, mobilePlatform);
+                            });
                     })
-                    .then(() => {
-                        generator.step("mobilePlatform.runApp");
-                        Log.logMessage("Building and running application.");
-                        return mobilePlatform.runApp();
-                    })
-                    .then(() => {
-                        return this.attachRequest(request, packagerPort, mobilePlatform);
-                    });
-                })
-                .catch(error => this.bailOut(error.message));
+                    .catch(error => this.bailOut(error.message));
             });
 
         }
@@ -130,8 +144,8 @@ export function makeSession(debugSessionClass: typeof ChromeDebuggerCorePackage.
             // Then we tell the extension to stop monitoring the logcat, and then we disconnect the debugging session
             if (this.mobilePlatformOptions.platform === "android") {
                 this.remoteExtension.stopMonitoringLogcat()
-                .catch(reason => Log.logError(`WARNING: Couldn't stop monitoring logcat: ${reason.message || reason}\n`))
-                .finally(() => super.dispatchRequest(request));
+                    .catch(reason => Log.logError(`WARNING: Couldn't stop monitoring logcat: ${reason.message || reason}\n`))
+                    .finally(() => super.dispatchRequest(request));
             } else {
                 super.dispatchRequest(request);
             }
@@ -157,9 +171,10 @@ export function makeSession(debugSessionClass: typeof ChromeDebuggerCorePackage.
          * Attach should:
          * - Enable js debugging
          */
-        private attachRequest(request: VSCodeDebugAdapterPackage.Request,
-                              packagerPort: number,
-                              mobilePlatform?: GeneralMobilePlatform): Q.Promise<void> {
+        private attachRequest(
+            request: VSCodeDebugAdapterPackage.Request,
+            packagerPort: number,
+            mobilePlatform?: GeneralMobilePlatform): Q.Promise<void> {
             return TelemetryHelper.generate("attach", (generator) => {
                 return Q({})
                     .then(() => {

--- a/src/debugger/reactNativeDebugEntryPoint.ts
+++ b/src/debugger/reactNativeDebugEntryPoint.ts
@@ -4,11 +4,11 @@
 import * as fs from "fs";
 import * as path from "path";
 
-import {TelemetryHelper} from "../common/telemetryHelper";
-import {EntryPointHandler, ProcessType} from "../common/entryPointHandler";
-import {ErrorHelper} from "../common/error/errorHelper";
-import {InternalErrorCode} from "../common/error/internalErrorCode";
-import {NullTelemetryReporter, ReassignableTelemetryReporter} from "../common/telemetryReporters";
+import { TelemetryHelper } from "../common/telemetryHelper";
+import { EntryPointHandler, ProcessType } from "../common/entryPointHandler";
+import { ErrorHelper } from "../common/error/errorHelper";
+import { InternalErrorCode } from "../common/error/internalErrorCode";
+import { NullTelemetryReporter, ReassignableTelemetryReporter } from "../common/telemetryReporters";
 import { makeAdapter, makeSession } from "./nodeDebugWrapper";
 
 const version = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "..", "package.json"), "utf-8")).version;
@@ -21,57 +21,65 @@ function bailOut(reason: string): void {
     process.exit(1);
 }
 
+function codeToRun() {
+
+    /**
+     * For debugging React Native we basically want to debug node plus some other stuff.
+     * There is no need to create a new adapter for node because ther already exists one.
+     * We look for node debug adapter on client's computer so we can jump of on top of that.
+     */
+    let nodeDebugFolder: string;
+    let VSCodeDebugAdapter: typeof VSCodeDebugAdapterPackage;
+    let Node2DebugAdapter: typeof Node2DebugAdapterPackage.Node2DebugAdapter;
+    let ChromeDebuggerPackage: typeof ChromeDebuggerCorePackage;
+
+    // nodeDebugLocation.json is dynamically generated on extension activation.
+    // If it fails, we must not have been in a react native project
+    try {
+        /* tslint:disable:no-var-requires */
+        nodeDebugFolder = require("./nodeDebugLocation.json").nodeDebugPath;
+        VSCodeDebugAdapter = require(path.join(nodeDebugFolder, "node_modules/vscode-debugadapter"));
+        ChromeDebuggerPackage = require(path.join(nodeDebugFolder, "node_modules/vscode-chrome-debug-core"));
+        Node2DebugAdapter = require(path.join(nodeDebugFolder, "out/src/nodeDebugAdapter")).NodeDebugAdapter;
+        /* tslint:enable:no-var-requires */
+    } catch (e) {
+        // Nothing we can do here: can't even communicate back because we don't know how to speak debug adapter
+        bailOut("cannotFindDebugAdapter");
+    }
+
+    /**
+     * We did find chrome debugger package and node2 debug adapter. Lets create debug
+     * session and adapter with our customizations.
+     */
+    let session: typeof ChromeDebuggerCorePackage.ChromeDebugSession;
+    let adapter: typeof Node2DebugAdapterPackage.Node2DebugAdapter;
+
+    try {
+        /* Create customised react-native debug adapter based on Node-debug2 adapter */
+        adapter = makeAdapter(Node2DebugAdapter);
+        // Create a debug session class based on ChromeDebugSession
+        session = makeSession(ChromeDebuggerPackage.ChromeDebugSession,
+            { adapter, extensionName }, VSCodeDebugAdapter, telemetryReporter, extensionName, version);
+    } catch (e) {
+        const debugSession = new VSCodeDebugAdapter.DebugSession();
+        // Start session before sending any events otherwise the client wouldn't receive them
+        debugSession.start(process.stdin, process.stdout);
+        debugSession.sendEvent(new VSCodeDebugAdapter.OutputEvent("Unable to start debug adapter: " + e.toString(), "stderr"));
+        debugSession.sendEvent(new VSCodeDebugAdapter.TerminatedEvent());
+        bailOut(e.toString());
+    }
+
+    // Run the debug session for the node debug adapter with our modified requests
+    ChromeDebuggerPackage.ChromeDebugSession.run(session);
+}
+
 // Enable telemetry
-new EntryPointHandler(ProcessType.Debugger).runApp(extensionName, () => version,
-    ErrorHelper.getInternalError(InternalErrorCode.DebuggingFailed), telemetryReporter, () => {
-
-        /**
-         * For debugging React Native we basically want to debug node plus some other stuff.
-         * There is no need to create a new adapter for node because ther already exists one.
-         * We look for node debug adapter on client's computer so we can jump of on top of that.
-         */
-        let nodeDebugFolder: string;
-        let VSCodeDebugAdapter: typeof VSCodeDebugAdapterPackage;
-        let Node2DebugAdapter: typeof Node2DebugAdapterPackage.Node2DebugAdapter;
-        let ChromeDebuggerPackage: typeof ChromeDebuggerCorePackage;
-
-        // nodeDebugLocation.json is dynamically generated on extension activation.
-        // If it fails, we must not have been in a react native project
-        try {
-            /* tslint:disable:no-var-requires */
-            nodeDebugFolder = require("./nodeDebugLocation.json").nodeDebugPath;
-            VSCodeDebugAdapter = require(path.join(nodeDebugFolder, "node_modules/vscode-debugadapter"));
-            ChromeDebuggerPackage = require(path.join(nodeDebugFolder, "node_modules/vscode-chrome-debug-core"));
-            Node2DebugAdapter = require(path.join(nodeDebugFolder, "out/src/nodeDebugAdapter")).NodeDebugAdapter;
-            /* tslint:enable:no-var-requires */
-        } catch (e) {
-            // Nothing we can do here: can't even communicate back because we don't know how to speak debug adapter
-            bailOut("cannotFindDebugAdapter");
-        }
-
-        /**
-         * We did find chrome debugger package and node2 debug adapter. Lets create debug
-         * session and adapter with our customizations.
-         */
-        let session: typeof ChromeDebuggerCorePackage.ChromeDebugSession;
-        let adapter: typeof Node2DebugAdapterPackage.Node2DebugAdapter;
-
-        try {
-            /* Create customised react-native debug adapter based on Node-debug2 adapter */
-            adapter = makeAdapter(Node2DebugAdapter);
-            // Create a debug session class based on ChromeDebugSession
-            session = makeSession(ChromeDebuggerPackage.ChromeDebugSession,
-                { adapter, extensionName }, VSCodeDebugAdapter, telemetryReporter, extensionName, version);
-        } catch (e) {
-            const debugSession = new VSCodeDebugAdapter.DebugSession();
-            // Start session before sending any events otherwise the client wouldn't receive them
-            debugSession.start(process.stdin, process.stdout);
-            debugSession.sendEvent(new VSCodeDebugAdapter.OutputEvent("Unable to start debug adapter: " + e.toString(), "stderr"));
-            debugSession.sendEvent(new VSCodeDebugAdapter.TerminatedEvent());
-            bailOut(e.toString());
-        }
-
-        // Run the debug session for the node debug adapter with our modified requests
-        ChromeDebuggerPackage.ChromeDebugSession.run(session);
-    });
+const entryPointHandler = new EntryPointHandler(ProcessType.Debugger);
+entryPointHandler.runApp(
+    extensionName,
+    () => version,
+    ErrorHelper.getInternalError(InternalErrorCode.DebuggingFailed),
+    telemetryReporter,
+    codeToRun
+);
 


### PR DESCRIPTION
When we "suppress" "terminate" event, client stays in "stopped" state.
I suggest send "continued" event to client instead of "terminated"	