### PR TITLE
Queued messages from RN App until app script will be executed

### DIFF
--- a/src/debugger/forkedAppWorker.ts
+++ b/src/debugger/forkedAppWorker.ts
@@ -28,6 +28,7 @@ export class ForkedAppWorker implements IDebuggeeWorker {
     private debuggeeProcess: child_process.ChildProcess = null;
     /** A deferred that we use to make sure that worker has been loaded completely defore start sending IPC messages */
     private workerLoaded = Q.defer<void>();
+    private bundleLoaded = Q.defer<void>();
 
     constructor(
         private packagerPort: number,
@@ -84,19 +85,25 @@ export class ForkedAppWorker implements IDebuggeeWorker {
     public postMessage(rnMessage: RNAppMessage): void {
         // Before sending messages, make sure that the worker is loaded
         this.workerLoaded.promise
-        .then(() => {
-            if (rnMessage.method !== "executeApplicationScript") return Q.resolve(rnMessage);
-
-            // When packager asks worker to load bundle we download that bundle and
-            // then set url field to point to that downloaded bundle, so the worker
-            // will take our modified bundle
-            Log.logInternalMessage(LogLevel.Info, "Packager requested runtime to load script from " + rnMessage.url);
-            return this.scriptImporter.downloadAppScript(rnMessage.url)
-                .then(downloadedScript => {
-                    return Object.assign({}, rnMessage, { url: downloadedScript.filepath });
-                });
-        })
-        .done((message: RNAppMessage) => this.debuggeeProcess.send({ data: message }),
+            .then(() => {
+                if (rnMessage.method !== "executeApplicationScript") {
+                    // Before sending messages, make sure that the app script executed
+                    return this.bundleLoaded.promise.then(() => {
+                        return rnMessage;
+                    });
+                } else {
+                    // When packager asks worker to load bundle we download that bundle and
+                    // then set url field to point to that downloaded bundle, so the worker
+                    // will take our modified bundle
+                    Log.logInternalMessage(LogLevel.Info, "Packager requested runtime to load script from " + rnMessage.url);
+                    return this.scriptImporter.downloadAppScript(rnMessage.url)
+                        .then(downloadedScript => {
+                            this.bundleLoaded.resolve(void 0);
+                            return Object.assign({}, rnMessage, { url: downloadedScript.filepath });
+                        });
+                }
+            })
+            .done((message: RNAppMessage) => this.debuggeeProcess.send({ data: message }),
             reason => printDebuggingError(`Couldn't import script at <${rnMessage.url}>`, reason));
     }
 }


### PR DESCRIPTION
Since react-native@0.45 when RN App emit message for debugWorker it doesn't wait response for `"method":"executeApplicationScript"` and emit new messages before app script executed
#459 