### PR TITLE
Fix 'react-native run-ios' failure from command palette

### DIFF
--- a/src/common/commandExecutor.ts
+++ b/src/common/commandExecutor.ts
@@ -120,7 +120,7 @@ export class CommandExecutor {
     /**
      * Executes a react native command and waits for its completion.
      */
-    public spawnReactCommand(command: string, args?: string[], options: Options = {}): ISpawnResult {
+    public spawnReactCommand(command: string, args: string[] = [], options: Options = {}): ISpawnResult {
         const reactCommand = HostPlatform.getNpmCliCommand(CommandExecutor.ReactNativeCommand);
         return this.spawnChildProcess(reactCommand, [command, ...args], options);
     }

--- a/src/extension/commandPaletteHandler.ts
+++ b/src/extension/commandPaletteHandler.ts
@@ -108,7 +108,8 @@ export class CommandPaletteHandler {
         TargetPlatformHelper.checkTargetPlatformSupport("ios");
         return this.executeCommandInContext("runIos", () => {
             // Set the Debugging setting to disabled, because in iOS it's persisted across runs of the app
-            return new IOSDebugModeManager(this.workspaceRoot).setSimulatorJSDebuggingModeSetting(/*enable=*/ false)
+            return new IOSDebugModeManager(this.workspaceRoot)
+                .setSimulatorJSDebuggingModeSetting(/*enable=*/ false)
                 .catch(() => { }) // If setting the debugging mode fails, we ignore the error and we run the run ios command anyways
                 .then(() => this.executeReactNativeRunCommand("run-ios"));
         });
@@ -144,9 +145,10 @@ export class CommandPaletteHandler {
      * {command} The command to be executed
      * {args} The arguments to be passed to the command
      */
-    private executeReactNativeRunCommand(command: string, args?: string[]): Q.Promise<void> {
+    private executeReactNativeRunCommand(command: string, args: string[] = []): Q.Promise<void> {
         return this.executeWithPackagerRunning(() => {
-            return new CommandExecutor(this.workspaceRoot).spawnReactCommand(command, args).outcome;
+            return new CommandExecutor(this.workspaceRoot)
+                .spawnReactCommand(command, args).outcome;
         });
     }
 

--- a/src/test/common/commandExecutor.test.ts
+++ b/src/test/common/commandExecutor.test.ts
@@ -2,23 +2,39 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 import {CommandExecutor} from "../../common/commandExecutor";
-import {Log} from "../../common/log/log";
+import { Log } from "../../common/log/log";
 
+import { Node } from "../../common/node/node";
+import { ChildProcess } from "../../common/node/childProcess";
+
+
+import { EventEmitter } from "events";
 import * as assert from "assert";
 import * as semver from "semver";
 import * as sinon from "sinon";
 import * as Q from "q";
 
 suite("commandExecutor", function() {
-    suite("commonContext", function() {
+    suite("commonContext", function () {
+
+        let childProcessStubInstance = new ChildProcess();
+        let childProcessStub: Sinon.SinonStub & ChildProcess;
+
         teardown(function() {
-            let mockedMethods = [Log.logMessage, Log.logCommandStatus];
+            let mockedMethods = [Log.logMessage, Log.logCommandStatus, ...Object.keys(childProcessStubInstance)];
 
             mockedMethods.forEach((method) => {
                 if (method.hasOwnProperty("restore")) {
                     (<any>method).restore();
                 }
             });
+
+            childProcessStub.restore();
+        });
+
+        setup(() => {
+            childProcessStub = sinon.stub(Node, "ChildProcess")
+                .returns(childProcessStubInstance) as ChildProcess & Sinon.SinonStub;
         });
 
         test("should execute a command", function() {
@@ -98,6 +114,21 @@ suite("commandExecutor", function() {
                     assert.equal(reason.errorCode, 101);
                     assert.equal(reason.errorLevel, 0);
                 }).done(() => done(), done);
+        });
+
+        test("should not fail on react-native command without arguments", function (done: MochaDone) {
+            (sinon.stub(childProcessStubInstance, "spawn") as Sinon.SinonStub)
+                .returns({
+                    stdout: new EventEmitter(),
+                    stderr: new EventEmitter(),
+                    outcome: Promise.resolve(void 0),
+                });
+
+            new CommandExecutor()
+                .spawnReactCommand("run-ios").outcome
+                .then(done, err => {
+                    assert.fail(null, null, "react-natibe command was not expected to fail", null);
+                });
         });
     });
 });


### PR DESCRIPTION
The bug is a regression introduced in 94cd514970 and was caused by passing undefined arg to `child_process.spawn` where it expects an array of string. We need to consider enabling `strictNullCheck` option in tsconfig to avoid similar issues in the future.

/cc @iToys

Fixes #500