### PR TITLE
Fix map issue on Windows when sourceRoot is used in map file

### DIFF
--- a/src/debugger/sourceMapsCombinator.ts
+++ b/src/debugger/sourceMapsCombinator.ts
@@ -8,7 +8,7 @@ import * as path from "path";
 import { SourceMapConsumer, RawSourceMap, SourceMapGenerator, MappingItem, Mapping, Position, NullableMappedPosition } from "source-map";
 import sourceMapResolve = require("source-map-resolve");
 
-const DISK_LETTER_RE: RegExp = /^[a-z]:/i;
+const DISK_LETTER_RE: RegExp = /^(?:[a-z]{2,}:\/\/\/)?[a-z]:/i;
 
 export class SourceMapsCombinator {
 


### PR DESCRIPTION
According to example from #561, debugging is not working properly when trying to set breakpoints in Haxe `.hx` files, it happens because Haxe adds `sourceRoot` with value `file:///` to .map file and it doesn't play well in our .map paths resolution for Windows paths. This PR fixes mapping for Haxe projects.