### PR TITLE
Fix haul project debug

### DIFF
--- a/src/common/reactNativeProjectHelper.ts
+++ b/src/common/reactNativeProjectHelper.ts
@@ -24,4 +24,14 @@ export class ReactNativeProjectHelper {
                 return !!(version);
             });
     }
+
+    public static isHaulProject(projectRoot: string): boolean {
+        if (!projectRoot || !fs.existsSync(path.join(projectRoot, "package.json"))) {
+            return false;
+        }
+
+        const packageJson = require(path.join(projectRoot, "package.json"));
+        const haulVersion = packageJson.devDependencies.haul;
+        return !!haulVersion;
+    }
 }

--- a/src/debugger/scriptImporter.ts
+++ b/src/debugger/scriptImporter.ts
@@ -77,7 +77,8 @@ export class ScriptImporter {
             })
             .then((rnVersion: string) => {
                 let newPackager = "";
-                if (semver.gte(rnVersion, "0.50.0")) {
+                const isHaulProject = ReactNativeProjectHelper.isHaulProject(projectRootPath);
+                if (semver.gte(rnVersion, "0.50.0") && !isHaulProject) {
                     newPackager = "debugger-ui/";
                 }
                 let debuggerWorkerURL = `http://${this.packagerAddress}:${this.packagerPort}/${newPackager}${ScriptImporter.DEBUGGER_WORKER_FILENAME}`;


### PR DESCRIPTION
- According to #588, haul `debuggerWorker` url is located in package root, not in `/debugger-ui` like RN packager >= 0.50.0.
- Current haul `debuggerWorker` uses `fetch`, so PR provides `fetch` replacement to patched `debuggerWorker`