### PR TITLE
Debugger for react-native-windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -248,7 +248,13 @@
             "properties": {
               "platform": {
                 "type": "string",
-                "description": "The platform ('ios' or 'android') to target"
+                "enum": [
+                      "ios",
+                      "android",
+                      "exponent",
+                      "windows"
+                    ],
+                "description": "The platform to target"
               },
               "program": {
                 "type": "string",

--- a/src/common/hostPlatform.ts
+++ b/src/common/hostPlatform.ts
@@ -62,7 +62,14 @@ class WindowsHostPlatform implements IHostPlatform {
     }
 
     public isCompatibleWithTarget(targetPlatformId: TargetPlatformId): boolean {
-        return targetPlatformId === TargetPlatformId.ANDROID || targetPlatformId === TargetPlatformId.EXPONENT;
+        switch (targetPlatformId) {
+            case TargetPlatformId.ANDROID:
+            case TargetPlatformId.EXPONENT:
+            case TargetPlatformId.WINDOWS:
+                return true;
+            default:
+                return false;
+        }
     }
 }
 
@@ -109,7 +116,14 @@ class OSXHostPlatform extends UnixHostPlatform {
     }
 
     public isCompatibleWithTarget(targetPlatformId: TargetPlatformId): boolean {
-        return targetPlatformId === TargetPlatformId.ANDROID || targetPlatformId === TargetPlatformId.IOS || targetPlatformId === TargetPlatformId.EXPONENT;
+        switch (targetPlatformId) {
+            case TargetPlatformId.ANDROID:
+            case TargetPlatformId.EXPONENT:
+            case TargetPlatformId.IOS:
+                return true;
+            default:
+                return false;
+        }
     }
 }
 
@@ -130,7 +144,13 @@ class LinuxHostPlatform extends UnixHostPlatform {
     }
 
     public isCompatibleWithTarget(targetPlatformId: TargetPlatformId): boolean {
-        return targetPlatformId === TargetPlatformId.ANDROID || targetPlatformId === TargetPlatformId.EXPONENT;
+        switch (targetPlatformId) {
+            case TargetPlatformId.ANDROID:
+            case TargetPlatformId.EXPONENT:
+                return true;
+            default:
+                return false;
+        }
     }
 }
 

--- a/src/common/targetPlatformHelper.ts
+++ b/src/common/targetPlatformHelper.ts
@@ -13,6 +13,7 @@ export enum TargetPlatformId {
     ANDROID,
     IOS,
     EXPONENT,
+    WINDOWS,
 }
 
 export class TargetPlatformHelper {
@@ -27,6 +28,8 @@ export class TargetPlatformHelper {
                 return TargetPlatformId.IOS;
             case "exponent":
                 return TargetPlatformId.EXPONENT;
+            case "windows":
+                return TargetPlatformId.WINDOWS;
             default:
                 throw new Error(`The target platform ${platformName} is not supported.`);
         }

--- a/src/extension/launchArgs.ts
+++ b/src/extension/launchArgs.ts
@@ -11,7 +11,6 @@ export interface ILaunchArgs {
     projectRoot: string;
     target?: "simulator" | "device";
     debugAdapterPort?: number;
-    logCatArguments?: any;
     packagerPort?: any;
     runArguments?: string[];
     env?: any;
@@ -24,6 +23,7 @@ export interface ILaunchArgs {
 
 export interface IAndroidRunOptions extends ILaunchArgs {
     variant?: string;
+    logCatArguments?: any;
 }
 
 export interface IIOSRunOptions extends ILaunchArgs {
@@ -31,6 +31,9 @@ export interface IIOSRunOptions extends ILaunchArgs {
     iosRelativeProjectPath?: string; // TODO Remove deprecated
 }
 
-export interface IRunOptions extends IAndroidRunOptions, IIOSRunOptions  {
+export interface IWindowsRunOptions extends ILaunchArgs {
+}
+
+export interface IRunOptions extends IAndroidRunOptions, IIOSRunOptions, IWindowsRunOptions  {
 
 }

--- a/src/extension/platformResolver.ts
+++ b/src/extension/platformResolver.ts
@@ -4,6 +4,7 @@
 import {IRunOptions} from "./launchArgs";
 import {IOSPlatform} from "./ios/iOSPlatform";
 import {AndroidPlatform} from "./android/androidPlatform";
+import {WindowsPlatform} from "./windows/windowsPlatform";
 import {GeneralMobilePlatform, MobilePlatformDeps} from "../extension/generalMobilePlatform";
 import {ExponentPlatform} from "./exponent/exponentPlatform";
 
@@ -22,6 +23,8 @@ export class PlatformResolver {
                 return new AndroidPlatform(runOptions, platformDeps);
             case "exponent":
                 return new ExponentPlatform(runOptions, platformDeps);
+            case "windows":
+                return new WindowsPlatform(runOptions, platformDeps);
             default:
                 return new GeneralMobilePlatform(runOptions, platformDeps);
         }

--- a/src/extension/windows/windowsPlatform.ts
+++ b/src/extension/windows/windowsPlatform.ts
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+import * as Q from "q";
+
+import {GeneralMobilePlatform, MobilePlatformDeps } from "../generalMobilePlatform";
+import {IWindowsRunOptions} from "../launchArgs";
+import {OutputVerifier, PatternToFailure} from "../../common/outputVerifier";
+import {TelemetryHelper} from "../../common/telemetryHelper";
+import {CommandExecutor} from "../../common/commandExecutor";
+import {ReactNativeProjectHelper} from "../../common/reactNativeProjectHelper";
+
+/**
+ * Windows specific platform implementation for debugging RN applications.
+ */
+export class WindowsPlatform extends GeneralMobilePlatform {
+
+    private static SUCCESS_PATTERNS = [
+        "Installing new version of the app",
+        "Starting the app",
+    ];
+    private static FAILURE_PATTERNS: PatternToFailure[] = [
+        {
+            pattern: "Unrecognized command 'run-windows'",
+            message: "'rnpm-plugin-windows' doesn't install",
+        },
+    ];
+
+    constructor(protected runOptions: IWindowsRunOptions, platformDeps: MobilePlatformDeps = {}) {
+        super(runOptions, platformDeps);
+    }
+
+    public runApp(enableDebug: boolean = true): Q.Promise<void> {
+        return TelemetryHelper.generate("WindowsPlatform.runApp", () => {
+            const runArguments = this.getRunArgument();
+            const env = this.getEnvArgument();
+
+            if (enableDebug) {
+                runArguments.push("--proxy");
+            }
+
+            return ReactNativeProjectHelper.getReactNativeVersion(this.runOptions.projectRoot)
+                .then(version => {
+                    // TODO Uncomment when it will be implemented in `react-native-windows`
+                    // if (semver.gte(version, WindowsPlatform.NO_PACKAGER_VERSION)) {
+                    //     runArguments.push("--no-packager");
+                    // }
+
+                    const runWindowsSpawn = new CommandExecutor(this.projectPath, this.logger).spawnReactCommand("run-windows", runArguments, {env});
+                    return new OutputVerifier(() => Q(WindowsPlatform.SUCCESS_PATTERNS), () => Q(WindowsPlatform.FAILURE_PATTERNS))
+                        .process(runWindowsSpawn);
+                });
+        });
+    }
+
+    public prewarmBundleCache(): Q.Promise<void> {
+        return this.packager.prewarmBundleCache("windows");
+    }
+
+    public getRunArgument(): string[] {
+        let runArguments: string[] = [];
+
+        if (this.runOptions.runArguments  && this.runOptions.runArguments.length > 0) {
+            runArguments.push(...this.runOptions.runArguments);
+        } else {
+            if (this.runOptions.target) {
+                runArguments.push(this.runOptions.target === "device" ? this.runOptions.target : "emulator");
+            }
+        }
+
+        return runArguments;
+    }
+}


### PR DESCRIPTION
Resolve #614 

For debugging `react-native-windows` add new `launch.json` configuration:
```
{
	"name": "Debug Windows",
	"program": "${workspaceRoot}/.vscode/launchReactNative.js",
	"type": "reactnative",
	"request": "launch",
	"platform": "windows",
	"sourceMaps": true,
	"outDir": "${workspaceRoot}/.vscode/.react"
},
```