### PR TITLE
Add more specific activation event

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"Other"
 	],
 	"activationEvents": [
-		"*"
+		"workspaceContains:**/node_modules/react-native/package.json"
 	],
 	"main": "./src/extension/rn-extension",
 	"contributes": {


### PR DESCRIPTION
This PR prevents extension to be activated at VS Code start and force it to do that only if opened directory (or subdirectory) has react-native package installed.