### PR TITLE
fix-issue-with-sourcemaps RN54.x

### DIFF
--- a/src/common/reactNativeProjectHelper.ts
+++ b/src/common/reactNativeProjectHelper.ts
@@ -7,6 +7,12 @@ import * as path from "path";
 import {CommandExecutor} from "./commandExecutor";
 
 export class ReactNativeProjectHelper {
+
+    public static getRNVersionsWithBrokenMetroBundler() {
+        // https://github.com/Microsoft/vscode-react-native/issues/660 for details
+        return ["0.54.0", "0.54.1", "0.54.2"];
+    }
+
     public static getReactNativeVersion(projectRoot: string) {
         return new CommandExecutor(projectRoot).getReactNativeVersion();
     }

--- a/src/debugger/forkedAppWorker.ts
+++ b/src/debugger/forkedAppWorker.ts
@@ -129,7 +129,7 @@ export class ForkedAppWorker implements IDebuggeeWorker {
                             url: url.format(packagerUrl),
                         };
                         logger.verbose("Packager requested runtime to load script from " + rnMessage.url);
-                        return this.scriptImporter.downloadAppScript(<string>rnMessage.url)
+                        return this.scriptImporter.downloadAppScript(<string>rnMessage.url, this.projectRootPath)
                             .then((downloadedScript: DownloadedScript) => {
                                 this.bundleLoaded.resolve(void 0);
                                 return Object.assign({}, rnMessage, { url: downloadedScript.filepath });

--- a/src/debugger/sourceMap.ts
+++ b/src/debugger/sourceMap.ts
@@ -87,6 +87,11 @@ export class SourceMapUtil {
         }
     }
 
+    public appendSourceMapPaths(scriptBody: string, sourceMappingUrl: string) {
+        scriptBody += `//# sourceMappingURL=${sourceMappingUrl}`;
+        return scriptBody;
+    }
+
     /**
      * Updates source map URLs in the script body.
      */


### PR DESCRIPTION
Unfortunately RN54.x doesn't generate inlined ref to sourcemaps (issue with Metro bundler, should be fixed in future versions). So this PR focused to solve issues for current users unless it will not be fixed with new RN release. 

If you have any ideas how to fix this other way or see areas of improvements I'm all ears!  