### PR TITLE
Fix projectRoot settings for iOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 	],
 	"activationEvents": [
 		"onDebug",
-		"workspaceContains:./node_modules/react-native/package.json",
+		"workspaceContains:**/node_modules/react-native/package.json",
 		"onCommand:reactNative.runAndroidSimulator",
 		"onCommand:reactNative.runAndroidDevice",
 		"onCommand:reactNative.runIosSimulator",

--- a/src/extension/commandPaletteHandler.ts
+++ b/src/extension/commandPaletteHandler.ts
@@ -183,10 +183,11 @@ export class CommandPaletteHandler {
                     const runArgs = SettingsHelper.getRunArgs("ios", target, project.workspaceFolder.uri);
                     const envArgs = SettingsHelper.getEnvArgs("ios", target, project.workspaceFolder.uri);
                     const envFile = SettingsHelper.getEnvFile("ios", target, project.workspaceFolder.uri);
+                    const projectRoot = SettingsHelper.getReactNativeProjectRoot(project.workspaceFolder.uri.fsPath);
                     const platform = new IOSPlatform({
                         platform: "ios",
                         workspaceRoot: project.workspaceFolder.uri.fsPath,
-                        projectRoot: project.workspaceFolder.uri.fsPath,
+                        projectRoot: projectRoot,
                         packagerPort: packagerPort,
                         runArguments: runArgs,
                         env: envArgs,


### PR DESCRIPTION
Fixes two problems when settings `react-native-tools.projectRoot`, they both appear on iOS:

- `run-ios` is not using this settings, cause the command to fail
- `run-ios` would fail with `Cannot read property 'message' of undefined` *the first time* running after loading the workspace
  - When this setting is present, it usually means the react-native project is not at the root of the workspace, so the `activationEvents` will not be triggered based on its current condition
  - This means the first run of any extension command would try to activate the extension, and run the specific command
  - But unfortunately `onFolderAdded` function embeds many asynchronous computation, which would fall behind in the event loop compared to the actual command run itself, causes the command to fail, since the extension has not been activated properly yet