### PR TITLE
Add appcenter functionality suppression in case of appcenter extension installed

### DIFF
--- a/src/extension/appcenter/appCenterCommandPalleteHandler.ts
+++ b/src/extension/appcenter/appCenterCommandPalleteHandler.ts
@@ -32,7 +32,13 @@ export class AppCenterCommandPalleteHandler {
         this.appCenterManager = manager;
     }
 
-    public run(command: AppCenterCommandType): Q.Promise<void>  {
+    public run(command: AppCenterCommandType): Q.Promise<void> {
+
+        if (VsCodeUtils.appCenterExtensionIsInstalled()) {
+            VsCodeUtils.ShowInformationMessage(ACStrings.PleaseUseAppCenterExtension);
+            return Q.resolve(void 0);
+        }
+
         return ACUtils.isCodePushProject(this.appCenterManager.projectRootPath).then((isCodePush: boolean) => {
             if (!isCodePush) {
                 VsCodeUtils.ShowWarningMessage(ACStrings.NoCodePushDetectedMsg);

--- a/src/extension/appcenter/appCenterConstants.ts
+++ b/src/extension/appcenter/appCenterConstants.ts
@@ -12,6 +12,7 @@ export class ACConstants {
     public static AppCenterCodePushStatusBarColor: string = "#F3F3B2";
     public static AppCenterDefaultTargetBinaryVersion: string = "";
     public static AppCenterDefaultIsMandatoryParam: boolean = false;
+    public static AppCenterExtId: string = "vsmobile.vscode-appcenter";
 }
 
 export class ACCommandNames {

--- a/src/extension/appcenter/appCenterExtensionManager.ts
+++ b/src/extension/appcenter/appCenterExtensionManager.ts
@@ -42,17 +42,20 @@ export class AppCenterExtensionManager implements Disposable {
     }
 
     public setupAppCenterStatusBar(profile: Profile | null): Q.Promise<void> {
-        if (profile && profile.userName) {
+        if (!VsCodeUtils.appCenterExtensionIsInstalled()) {
+            if (profile && profile.userName) {
+                return VsCodeUtils.setStatusBar(this.appCenterStatusBarItem,
+                    `$(icon octicon-person) ${profile.userName}`,
+                    ACStrings.YouAreLoggedInMsg(profile.userName),
+                    `${ACConstants.ExtensionPrefixName}.${ACCommandNames.ShowMenu}`
+                );
+            }
             return VsCodeUtils.setStatusBar(this.appCenterStatusBarItem,
-                `$(icon octicon-person) ${profile.userName}`,
-                ACStrings.YouAreLoggedInMsg(profile.userName),
-                `${ACConstants.ExtensionPrefixName}.${ACCommandNames.ShowMenu}`
+                `$(icon octicon-sign-in) ${ACStrings.LoginToAppCenterButton}`,
+                ACStrings.UserMustSignIn,
+                `${ACConstants.ExtensionPrefixName}.${ACCommandNames.Login}`
             );
         }
-        return VsCodeUtils.setStatusBar(this.appCenterStatusBarItem,
-            `$(icon octicon-sign-in) ${ACStrings.LoginToAppCenterButton}`,
-            ACStrings.UserMustSignIn,
-            `${ACConstants.ExtensionPrefixName}.${ACCommandNames.Login}`
-        );
+        return Q.resolve(void 0);
     }
 }

--- a/src/extension/appcenter/appCenterStrings.ts
+++ b/src/extension/appcenter/appCenterStrings.ts
@@ -33,6 +33,7 @@ export class ACStrings {
     public static PleaseProvideTargetBinaryVersion: string = "Please provide semver compliant version";
     public static LogoutMenuLabel: string = "Logout";
     public static MenuTitlePlaceholder: string = "Please select action";
+    public static PleaseUseAppCenterExtension: string = "We've noticed that you have AppCenter extension installed. Please use it's command instead.";
 
     public static YouAreLoggedInMsg: (name: string) => string = (name: string) => {
          return `You are logged into App Center as '${name}'`;

--- a/src/extension/appcenter/helpers/vscodeUtils.ts
+++ b/src/extension/appcenter/helpers/vscodeUtils.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 import { MessageTypes, ACConstants } from "../appCenterConstants";
-import { commands, StatusBarItem, window, MessageItem } from "vscode";
+import { commands, StatusBarItem, window, MessageItem, extensions } from "vscode";
 import { ACUtils } from "./utils";
 import * as Q from "q";
 
@@ -55,6 +55,11 @@ export class VsCodeUtils {
                 return;
             });
         });
+    }
+
+    public static appCenterExtensionIsInstalled() {
+        const appcenterExt = extensions.getExtension(ACConstants.AppCenterExtId);
+        return appcenterExt ? true : false;
     }
 
     private static async showMessage(messageToDisplay: string, type: MessageTypes, ...urlMessageItem: IButtonMessageItem[]): Promise<IButtonMessageItem | undefined> {


### PR DESCRIPTION
This PR does the following in case appcenter extension is installed:
* Hides appcenter status bar
* If appcenter command is called it exits with informational message.