### PR TITLE
Fix error logging for palette commands

### DIFF
--- a/src/common/error/errorStrings.ts
+++ b/src/common/error/errorStrings.ts
@@ -27,6 +27,7 @@ export const ERROR_STRINGS = {
     "FailedToRunOnAndroid": "Failed to run the application in Android",
     "FailedToRunOnIos": "Failed to run the application in iOS",
     "FailedToRunExponent": "Failed to run the application in Exponent",
+    "FailedToPublishToExpHost": "Failed to publish the application to Exponent",
     "FailedToStartPackager": "Failed to start the React Native packager",
     "FailedToStopPackager": "Failed to stop the React Native packager",
     "FailedToRestartPackager": "Failed to restart the React Native packager",

--- a/src/extension/commandPaletteHandler.ts
+++ b/src/extension/commandPaletteHandler.ts
@@ -117,7 +117,11 @@ export class CommandPaletteHandler {
      * Executes the 'react-native run-android' command
      */
     public static runAndroid(target: TargetType = "simulator"): Q.Promise<void> {
-        TargetPlatformHelper.checkTargetPlatformSupport("android");
+        try {
+            TargetPlatformHelper.checkTargetPlatformSupport("android");
+        } catch (e) {
+            return Q.reject(e);
+        }
         return this.selectProject()
             .then((project: IReactNativeProject) => {
                 return this.executeCommandInContext("runAndroid", project.workspaceFolder, () => {
@@ -143,7 +147,11 @@ export class CommandPaletteHandler {
      * Executes the 'react-native run-ios' command
      */
     public static runIos(target: TargetType = "simulator"): Q.Promise<void> {
-        TargetPlatformHelper.checkTargetPlatformSupport("ios");
+        try {
+            TargetPlatformHelper.checkTargetPlatformSupport("ios");
+        } catch (e) {
+            return Q.reject(e);
+        }
         return this.selectProject()
             .then((project: IReactNativeProject) => {
                 return this.executeCommandInContext("runIos", project.workspaceFolder, () => {

--- a/src/extension/commandPaletteHandler.ts
+++ b/src/extension/commandPaletteHandler.ts
@@ -117,13 +117,9 @@ export class CommandPaletteHandler {
      * Executes the 'react-native run-android' command
      */
     public static runAndroid(target: TargetType = "simulator"): Q.Promise<void> {
-        try {
-            TargetPlatformHelper.checkTargetPlatformSupport("android");
-        } catch (e) {
-            return Q.reject(e);
-        }
         return this.selectProject()
             .then((project: IReactNativeProject) => {
+                TargetPlatformHelper.checkTargetPlatformSupport("android");
                 return this.executeCommandInContext("runAndroid", project.workspaceFolder, () => {
                     const runOptions = CommandPaletteHandler.getRunOptions(project, "android", target);
                     const platform = new AndroidPlatform(runOptions, {
@@ -147,13 +143,9 @@ export class CommandPaletteHandler {
      * Executes the 'react-native run-ios' command
      */
     public static runIos(target: TargetType = "simulator"): Q.Promise<void> {
-        try {
-            TargetPlatformHelper.checkTargetPlatformSupport("ios");
-        } catch (e) {
-            return Q.reject(e);
-        }
         return this.selectProject()
             .then((project: IReactNativeProject) => {
+                TargetPlatformHelper.checkTargetPlatformSupport("ios");
                 return this.executeCommandInContext("runIos", project.workspaceFolder, () => {
                     const runOptions = CommandPaletteHandler.getRunOptions(project, "ios", target);
                     const platform = new IOSPlatform(runOptions, {

--- a/src/extension/rn-extension.ts
+++ b/src/extension/rn-extension.ts
@@ -199,8 +199,8 @@ function registerReactNativeCommands(context: vscode.ExtensionContext): void {
     registerVSCodeCommand(context, "stopPackager", ErrorHelper.getInternalError(InternalErrorCode.FailedToStopPackager), () => CommandPaletteHandler.stopPackager());
     registerVSCodeCommand(context, "restartPackager", ErrorHelper.getInternalError(InternalErrorCode.FailedToRestartPackager), () => CommandPaletteHandler.restartPackager());
     registerVSCodeCommand(context, "publishToExpHost", ErrorHelper.getInternalError(InternalErrorCode.FailedToPublishToExpHost), () => CommandPaletteHandler.publishToExpHost());
-    registerVSCodeCommand(context, "showDevMenu", ErrorHelper.getInternalError(InternalErrorCode.CommandFailed), () => CommandPaletteHandler.showDevMenu());
-    registerVSCodeCommand(context, "reloadApp", ErrorHelper.getInternalError(InternalErrorCode.CommandFailed), () => CommandPaletteHandler.reloadApp());
+    registerVSCodeCommand(context, "showDevMenu", ErrorHelper.getInternalError(InternalErrorCode.CommandFailed, "showDevMenu"), () => CommandPaletteHandler.showDevMenu());
+    registerVSCodeCommand(context, "reloadApp", ErrorHelper.getInternalError(InternalErrorCode.CommandFailed, "reloadApp"), () => CommandPaletteHandler.reloadApp());
 }
 
 function registerVSCodeCommand(context: vscode.ExtensionContext, commandName: string, error: InternalError, commandHandler: () => Q.Promise<void>): void {

--- a/src/extension/rn-extension.ts
+++ b/src/extension/rn-extension.ts
@@ -199,8 +199,8 @@ function registerReactNativeCommands(context: vscode.ExtensionContext): void {
     registerVSCodeCommand(context, "stopPackager", ErrorHelper.getInternalError(InternalErrorCode.FailedToStopPackager), () => CommandPaletteHandler.stopPackager());
     registerVSCodeCommand(context, "restartPackager", ErrorHelper.getInternalError(InternalErrorCode.FailedToRestartPackager), () => CommandPaletteHandler.restartPackager());
     registerVSCodeCommand(context, "publishToExpHost", ErrorHelper.getInternalError(InternalErrorCode.FailedToPublishToExpHost), () => CommandPaletteHandler.publishToExpHost());
-    registerVSCodeCommand(context, "showDevMenu", ErrorHelper.getInternalError(InternalErrorCode.CommandFailed, "showDevMenu"), () => CommandPaletteHandler.showDevMenu());
-    registerVSCodeCommand(context, "reloadApp", ErrorHelper.getInternalError(InternalErrorCode.CommandFailed, "reloadApp"), () => CommandPaletteHandler.reloadApp());
+    registerVSCodeCommand(context, "showDevMenu", ErrorHelper.getInternalError(InternalErrorCode.CommandFailed, "React Native: Show Dev Menu"), () => CommandPaletteHandler.showDevMenu());
+    registerVSCodeCommand(context, "reloadApp", ErrorHelper.getInternalError(InternalErrorCode.CommandFailed, "React Native: Reload App"), () => CommandPaletteHandler.reloadApp());
 }
 
 function registerVSCodeCommand(context: vscode.ExtensionContext, commandName: string, error: InternalError, commandHandler: () => Q.Promise<void>): void {


### PR DESCRIPTION
This PR fixes error logs in case of running Palette commands from inside non-RN project.
#652 

Command "Publish to Exponent"
before
![image](https://user-images.githubusercontent.com/30265843/42223733-2945248c-7ee1-11e8-8387-f2af9b8064d3.png)

after
![image](https://user-images.githubusercontent.com/30265843/42223914-922b5c6e-7ee1-11e8-8e20-a14a7c35abc0.png)

Command "Reload App"
before
![image](https://user-images.githubusercontent.com/30265843/42223810-564906a6-7ee1-11e8-8e0d-0c6ef0b51afd.png)

after
![image](https://user-images.githubusercontent.com/30265843/42223936-9fb137aa-7ee1-11e8-8f95-b55c1ef935cc.png)

Command "Run iOS on Device"
before
![image](https://user-images.githubusercontent.com/30265843/42223842-684ef770-7ee1-11e8-981c-32741004aeec.png)

after
![image](https://user-images.githubusercontent.com/30265843/42223962-b146ff68-7ee1-11e8-8386-3db440c38ee9.png)

Command "Show Dev Menu"
before
![image](https://user-images.githubusercontent.com/30265843/42223872-79413e4e-7ee1-11e8-8947-8900fc7477a8.png)

after
![image](https://user-images.githubusercontent.com/30265843/42223985-be6bbf4e-7ee1-11e8-9ee5-545caf2bb538.png)
