### PR TITLE
Forceibly remove process.versions for debugger worker

### DIFF
--- a/src/debugger/appWorker.ts
+++ b/src/debugger/appWorker.ts
@@ -51,6 +51,11 @@ Object.defineProperty(global, "GLOBAL", {
     enumerable: true,
     value: global
 });
+// Prevent leaking process.versions from debugger process to
+// worker because pure React Native doesn't do that and some packages as js-md5 rely on this behavior
+Object.defineProperty(process, "versions", {
+    value: undefined
+});
 
 var vscodeHandlers = {
     'vscode_reloadApp': function () {


### PR DESCRIPTION
This PR prevents leaking process.versions and process.versions from debugger process to
worker because pure React Native doesn't do that and some packages as js-md5 [rely on this behavior](https://github.com/emn178/js-md5/blob/master/src/md5.js#L20).

Resolves #747.