### PR TITLE
[Android] Add reading SDK location from local.properties

### DIFF
--- a/src/common/node/fileSystem.ts
+++ b/src/common/node/fileSystem.ts
@@ -123,6 +123,10 @@ export class FileSystem {
         return Q.nfcall<string>(this.fs.readFile, filename, encoding);
     }
 
+    public readFileSync(filename: string, encoding: string = "utf8"): string {
+        return this.fs.readFileSync(filename, encoding);
+    }
+
     public writeFile(filename: string, data: any): Q.Promise<void> {
         return Q.nfcall<void>(this.fs.writeFile, filename, data);
     }

--- a/src/common/node/fileSystem.ts
+++ b/src/common/node/fileSystem.ts
@@ -123,10 +123,6 @@ export class FileSystem {
         return Q.nfcall<string>(this.fs.readFile, filename, encoding);
     }
 
-    public readFileSync(filename: string, encoding: string = "utf8"): string {
-        return this.fs.readFileSync(filename, encoding);
-    }
-
     public writeFile(filename: string, data: any): Q.Promise<void> {
         return Q.nfcall<void>(this.fs.writeFile, filename, data);
     }

--- a/src/extension/android/adb.ts
+++ b/src/extension/android/adb.ts
@@ -3,8 +3,12 @@
 
 import * as Q from "q";
 
-import {ChildProcess} from "../../common/node/childProcess";
+import { ChildProcess, ISpawnResult } from "../../common/node/childProcess";
 import {CommandExecutor} from "../../common/commandExecutor";
+import * as path from "path";
+import { FileSystem } from "../../common/node/fileSystem";
+import { ILogger } from "../log/LogHelper";
+const fs = new FileSystem();
 
 // See android versions usage at: http://developer.android.com/about/dashboards/index.html
 export enum AndroidAPILevel {
@@ -41,13 +45,22 @@ export interface IDevice {
 const AndroidSDKEmulatorPattern = /^emulator-\d{1,5}$/;
 
 export class AdbHelper {
-    private static childProcess: ChildProcess = new ChildProcess();
-    private static commandExecutor: CommandExecutor = new CommandExecutor();
+    private childProcess: ChildProcess = new ChildProcess();
+    private commandExecutor: CommandExecutor = new CommandExecutor();
+    private adbExecutable: string = "";
+
+    constructor(projectRoot: string, logger: ILogger) {
+
+        // Trying to read sdk location from local.properties file and if we succueded then
+        // we would run adb from inside it, otherwise we would rely to PATH
+        const sdkLocation = this.getSdkLocationFromLocalPropertiesFile(projectRoot, logger);
+        this.adbExecutable = sdkLocation ? `${path.join(sdkLocation, "platform-tools", "adb")}` : "adb";
+    }
 
     /**
      * Gets the list of Android connected devices and emulators.
      */
-    public static getConnectedDevices(): Q.Promise<IDevice[]> {
+    public getConnectedDevices(): Q.Promise<IDevice[]> {
         return this.childProcess.execToString("adb devices")
             .then(output => {
                 return this.parseConnectedDevices(output);
@@ -57,8 +70,8 @@ export class AdbHelper {
     /**
      * Broadcasts an intent to reload the application in debug mode.
      */
-    public static switchDebugMode(projectRoot: string, packageName: string, enable: boolean, debugTarget?: string): Q.Promise<void> {
-        let enableDebugCommand = `adb ${debugTarget ? "-s " + debugTarget : ""} shell am broadcast -a "${packageName}.RELOAD_APP_ACTION" --ez jsproxy ${enable}`;
+    public switchDebugMode(projectRoot: string, packageName: string, enable: boolean, debugTarget?: string): Q.Promise<void> {
+        let enableDebugCommand = `${this.adbExecutable} ${debugTarget ? "-s " + debugTarget : ""} shell am broadcast -a "${packageName}.RELOAD_APP_ACTION" --ez jsproxy ${enable}`;
         return new CommandExecutor(projectRoot).execute(enableDebugCommand)
             .then(() => { // We should stop and start application again after RELOAD_APP_ACTION, otherwise app going to hangs up
                 let deferred = Q.defer();
@@ -79,48 +92,52 @@ export class AdbHelper {
     /**
      * Sends an intent which launches the main activity of the application.
      */
-    public static launchApp(projectRoot: string, packageName: string, debugTarget?: string): Q.Promise<void> {
-        let launchAppCommand = `adb ${debugTarget ? "-s " + debugTarget : ""} shell am start -n ${packageName}/.MainActivity`;
+    public launchApp(projectRoot: string, packageName: string, debugTarget?: string): Q.Promise<void> {
+        let launchAppCommand = `${this.adbExecutable} ${debugTarget ? "-s " + debugTarget : ""} shell am start -n ${packageName}/.MainActivity`;
         return new CommandExecutor(projectRoot).execute(launchAppCommand);
     }
 
-    public static stopApp(projectRoot: string, packageName: string, debugTarget?: string): Q.Promise<void> {
-        let stopAppCommand = `adb ${debugTarget ? "-s " + debugTarget : ""} shell am force-stop ${packageName}`;
+    public stopApp(projectRoot: string, packageName: string, debugTarget?: string): Q.Promise<void> {
+        let stopAppCommand = `${this.adbExecutable} ${debugTarget ? "-s " + debugTarget : ""} shell am force-stop ${packageName}`;
         return new CommandExecutor(projectRoot).execute(stopAppCommand);
     }
 
-    public static apiVersion(deviceId: string): Q.Promise<AndroidAPILevel> {
+    public apiVersion(deviceId: string): Q.Promise<AndroidAPILevel> {
         return this.executeQuery(deviceId, "shell getprop ro.build.version.sdk").then(output =>
             parseInt(output, 10));
     }
 
-    public static reverseAdb(deviceId: string, packagerPort: number): Q.Promise<void> {
+    public reverseAdb(deviceId: string, packagerPort: number): Q.Promise<void> {
         return this.execute(deviceId, `reverse tcp:${packagerPort} tcp:${packagerPort}`);
     }
 
-    public static showDevMenu(deviceId?: string): Q.Promise<void> {
-        let command = `adb ${deviceId ? "-s " + deviceId : ""} shell input keyevent ${KeyEvents.KEYCODE_MENU}`;
+    public showDevMenu(deviceId?: string): Q.Promise<void> {
+        let command = `${this.adbExecutable} ${deviceId ? "-s " + deviceId : ""} shell input keyevent ${KeyEvents.KEYCODE_MENU}`;
         return this.commandExecutor.execute(command);
     }
 
-    public static reloadApp(deviceId?: string): Q.Promise<void> {
+    public reloadApp(deviceId?: string): Q.Promise<void> {
         let commands = [
-            `adb ${deviceId ? "-s " + deviceId : ""} shell input keyevent ${KeyEvents.KEYCODE_MENU}`,
-            `adb ${deviceId ? "-s " + deviceId : ""} shell input keyevent ${KeyEvents.KEYCODE_DPAD_UP}`,
-            `adb ${deviceId ? "-s " + deviceId : ""} shell input keyevent ${KeyEvents.KEYCODE_DPAD_CENTER}`,
+            `${this.adbExecutable} ${deviceId ? "-s " + deviceId : ""} shell input keyevent ${KeyEvents.KEYCODE_MENU}`,
+            `${this.adbExecutable} ${deviceId ? "-s " + deviceId : ""} shell input keyevent ${KeyEvents.KEYCODE_DPAD_UP}`,
+            `${this.adbExecutable} ${deviceId ? "-s " + deviceId : ""} shell input keyevent ${KeyEvents.KEYCODE_DPAD_CENTER}`,
         ];
 
         return this.executeChain(commands);
     }
 
-    public static getOnlineDevices(): Q.Promise<IDevice[]> {
+    public getOnlineDevices(): Q.Promise<IDevice[]> {
         return this.getConnectedDevices().then(devices => {
             return devices.filter(device =>
                 device.isOnline);
         });
     }
 
-    private static parseConnectedDevices(input: string): IDevice[] {
+    public startLogCat(adbParameters: string[]): ISpawnResult {
+        return new ChildProcess().spawn(`${this.adbExecutable}`, adbParameters);
+    }
+
+    private parseConnectedDevices(input: string): IDevice[] {
         let result: IDevice[] = [];
         let regex = new RegExp("^(\\S+)\\t(\\S+)$", "mg");
         let match = regex.exec(input);
@@ -131,27 +148,53 @@ export class AdbHelper {
         return result;
     }
 
-    private static extractDeviceType(id: string): DeviceType {
+    private extractDeviceType(id: string): DeviceType {
         return id.match(AndroidSDKEmulatorPattern)
             ? DeviceType.AndroidSdkEmulator
             : DeviceType.Other;
     }
 
-    private static executeQuery(deviceId: string, command: string): Q.Promise<string> {
+    private executeQuery(deviceId: string, command: string): Q.Promise<string> {
         return this.childProcess.execToString(this.generateCommandForDevice(deviceId, command));
     }
 
-    private static execute(deviceId: string, command: string): Q.Promise<void> {
+    private execute(deviceId: string, command: string): Q.Promise<void> {
         return this.commandExecutor.execute(this.generateCommandForDevice(deviceId, command));
     }
 
-    private static executeChain(commands: string[]): Q.Promise<any> {
+    private executeChain(commands: string[]): Q.Promise<any> {
         return commands.reduce((promise, command) => {
             return promise.then(() => this.commandExecutor.execute(command));
         }, Q(void 0));
     }
 
-    private static generateCommandForDevice(deviceId: string, adbCommand: string): string {
-        return `adb -s "${deviceId}" ${adbCommand}`;
+    private generateCommandForDevice(deviceId: string, adbCommand: string): string {
+        return `${this.adbExecutable} -s "${deviceId}" ${adbCommand}`;
+    }
+
+    private getSdkLocationFromLocalPropertiesFile(projectRoot: string, logger: ILogger): string | null {
+        const localPropertiesFilePath = path.join(projectRoot, "android", "local.properties");
+        if (!fs.existsSync(localPropertiesFilePath)) {
+            logger.info(`local.properties file doesn't exist. Using Android SDK location from PATH.`);
+            return null;
+        }
+
+        let fileContent;
+        try {
+            fileContent = fs.readFileSync(localPropertiesFilePath);
+        } catch (e) {
+            logger.error(`Could read from ${localPropertiesFilePath}.`, e, e.stack);
+            logger.info(`Using Android SDK location from PATH.`);
+            return null;
+        }
+        const matches = fileContent.match(/^sdk\.dir=(.+)$/m);
+        if (!matches || !matches[1]) {
+            return null;
+        }
+
+        const sdkLocation = matches[1].trim();
+        logger.info(`Using Android SDK location defined in android/local.properties file: ${sdkLocation}.`);
+
+        return sdkLocation;
     }
 }

--- a/src/extension/android/adb.ts
+++ b/src/extension/android/adb.ts
@@ -61,7 +61,7 @@ export class AdbHelper {
      * Gets the list of Android connected devices and emulators.
      */
     public getConnectedDevices(): Q.Promise<IDevice[]> {
-        return this.childProcess.execToString("adb devices")
+        return this.childProcess.execToString(`${this.adbExecutable} devices`)
             .then(output => {
                 return this.parseConnectedDevices(output);
             });

--- a/src/extension/android/adb.ts
+++ b/src/extension/android/adb.ts
@@ -189,6 +189,7 @@ export class AdbHelper {
         }
         const matches = fileContent.match(/^sdk\.dir=(.+)$/m);
         if (!matches || !matches[1]) {
+            logger.info(`No sdk.dir value found in local.properties file. Using Android SDK location from PATH.`);
             return null;
         }
 

--- a/src/extension/android/androidPlatform.ts
+++ b/src/extension/android/androidPlatform.ts
@@ -45,8 +45,6 @@ export class AndroidPlatform extends GeneralMobilePlatform {
 
     private static RUN_ANDROID_SUCCESS_PATTERNS: string[] = ["BUILD SUCCESSFUL", "Starting the app", "Starting: Intent"];
 
-    private static platformToolsDirectory: string | null;
-
     private debugTarget: IDevice;
     private devices: IDevice[];
     private packageName: string;
@@ -156,14 +154,6 @@ export class AndroidPlatform extends GeneralMobilePlatform {
         }
 
         return runArguments;
-    }
-
-    public static getPlatformToolsDirectory() {
-        if (!this.platformToolsDirectory) {
-
-        }
-
-        return this.platformToolsDirectory;
     }
 
     private initializeTargetDevicesAndPackageName(): Q.Promise<void> {

--- a/src/extension/android/androidPlatform.ts
+++ b/src/extension/android/androidPlatform.ts
@@ -79,6 +79,11 @@ export class AndroidPlatform extends GeneralMobilePlatform {
         this.adbHelper = new AdbHelper(this.runOptions.projectRoot, this.logger);
     }
 
+    // TODO: remove this method when sinon will be updated to upper version. Now it is used for tests only.
+    public setAdbHelper(adbHelper: AdbHelper) {
+        this.adbHelper = adbHelper;
+    }
+
     public runApp(shouldLaunchInAllDevices: boolean = false): Q.Promise<void> {
         const extProps = {
             platform: {

--- a/src/extension/commandPaletteHandler.ts
+++ b/src/extension/commandPaletteHandler.ts
@@ -196,7 +196,11 @@ export class CommandPaletteHandler {
     public static showDevMenu(): Q.Promise<void> {
         return this.selectProject()
             .then((project: IReactNativeProject) => {
-                AndroidPlatform.showDevMenu()
+                const runOptions = CommandPaletteHandler.getRunOptions(project, "android");
+                const androidPlatform = new AndroidPlatform(runOptions, {
+                    packager: project.packager,
+                });
+                androidPlatform.showDevMenu()
                     .catch(() => { }); // Ignore any errors
                 IOSPlatform.showDevMenu(project.workspaceFolder.uri.fsPath)
                     .catch(() => { }); // Ignore any errors
@@ -207,7 +211,11 @@ export class CommandPaletteHandler {
     public static reloadApp(): Q.Promise<void> {
         return this.selectProject()
             .then((project: IReactNativeProject) => {
-                AndroidPlatform.reloadApp()
+                const runOptions = CommandPaletteHandler.getRunOptions(project, "android");
+                const androidPlatform = new AndroidPlatform(runOptions, {
+                    packager: project.packager,
+                });
+                androidPlatform.reloadApp()
                     .catch(() => { }); // Ignore any errors
                 IOSPlatform.reloadApp(project.workspaceFolder.uri.fsPath)
                     .catch(() => { }); // Ignore any errors

--- a/src/extension/commandPaletteHandler.ts
+++ b/src/extension/commandPaletteHandler.ts
@@ -7,7 +7,7 @@ import * as XDL from "./exponent/xdlInterface";
 import {SettingsHelper} from "./settingsHelper";
 import {OutputChannelLogger} from "./log/OutputChannelLogger";
 import {Packager} from "../common/packager";
-import {TargetType} from "./generalMobilePlatform";
+import {TargetType, GeneralMobilePlatform} from "./generalMobilePlatform";
 import {AndroidPlatform} from "./android/androidPlatform";
 import {IOSPlatform} from "./ios/iOSPlatform";
 import {ReactNativeProjectHelper} from "../common/reactNativeProjectHelper";
@@ -121,10 +121,7 @@ export class CommandPaletteHandler {
             .then((project: IReactNativeProject) => {
                 TargetPlatformHelper.checkTargetPlatformSupport("android");
                 return this.executeCommandInContext("runAndroid", project.workspaceFolder, () => {
-                    const runOptions = CommandPaletteHandler.getRunOptions(project, "android", target);
-                    const platform = new AndroidPlatform(runOptions, {
-                        packager: project.packager,
-                    });
+                    const platform = <AndroidPlatform>this.createPlatform(project, "android", AndroidPlatform, target);
                     return platform.beforeStartPackager()
                         .then(() => {
                             return platform.startPackager();
@@ -147,11 +144,7 @@ export class CommandPaletteHandler {
             .then((project: IReactNativeProject) => {
                 TargetPlatformHelper.checkTargetPlatformSupport("ios");
                 return this.executeCommandInContext("runIos", project.workspaceFolder, () => {
-                    const runOptions = CommandPaletteHandler.getRunOptions(project, "ios", target);
-                    const platform = new IOSPlatform(runOptions, {
-                        packager: project.packager,
-                    });
-
+                    const platform = <IOSPlatform>this.createPlatform(project, "ios", IOSPlatform, target);
                     return platform.beforeStartPackager()
                         .then(() => {
                             return platform.startPackager();
@@ -177,10 +170,7 @@ export class CommandPaletteHandler {
                 return this.loginToExponent(project)
                     .then(() => {
                         return this.executeCommandInContext("runExponent", project.workspaceFolder, () => {
-                            const runOptions = CommandPaletteHandler.getRunOptions(project, "exponent");
-                            const platform = new ExponentPlatform(runOptions, {
-                                packager: project.packager,
-                            });
+                            const platform = <ExponentPlatform>this.createPlatform(project, "exponent", ExponentPlatform);
                             return platform.beforeStartPackager()
                                 .then(() => {
                                     return platform.startPackager();
@@ -196,13 +186,11 @@ export class CommandPaletteHandler {
     public static showDevMenu(): Q.Promise<void> {
         return this.selectProject()
             .then((project: IReactNativeProject) => {
-                const runOptions = CommandPaletteHandler.getRunOptions(project, "android");
-                const androidPlatform = new AndroidPlatform(runOptions, {
-                    packager: project.packager,
-                });
+                const androidPlatform = <AndroidPlatform>this.createPlatform(project, "android", AndroidPlatform);
                 androidPlatform.showDevMenu()
                     .catch(() => { }); // Ignore any errors
-                IOSPlatform.showDevMenu(project.workspaceFolder.uri.fsPath)
+                const iosPlatform = <IOSPlatform>this.createPlatform(project, "ios", IOSPlatform);
+                iosPlatform.showDevMenu(project.workspaceFolder.uri.fsPath)
                     .catch(() => { }); // Ignore any errors
                 return Q.resolve(void 0);
             });
@@ -211,13 +199,11 @@ export class CommandPaletteHandler {
     public static reloadApp(): Q.Promise<void> {
         return this.selectProject()
             .then((project: IReactNativeProject) => {
-                const runOptions = CommandPaletteHandler.getRunOptions(project, "android");
-                const androidPlatform = new AndroidPlatform(runOptions, {
-                    packager: project.packager,
-                });
+                const androidPlatform = <AndroidPlatform>this.createPlatform(project, "android", AndroidPlatform);
                 androidPlatform.reloadApp()
                     .catch(() => { }); // Ignore any errors
-                IOSPlatform.reloadApp(project.workspaceFolder.uri.fsPath)
+                const iosPlatform = <IOSPlatform>this.createPlatform(project, "ios", IOSPlatform);
+                iosPlatform.reloadApp(project.workspaceFolder.uri.fsPath)
                     .catch(() => { }); // Ignore any errors
                 return Q.resolve(void 0);
             });
@@ -239,6 +225,13 @@ export class CommandPaletteHandler {
         }
 
         return "";
+    }
+
+    private static createPlatform(project: IReactNativeProject, platform: "ios" | "android" | "exponent", platformClass: typeof GeneralMobilePlatform, target?: TargetType): GeneralMobilePlatform {
+        const runOptions = CommandPaletteHandler.getRunOptions(project, platform, target);
+        return new platformClass(runOptions, {
+            packager: project.packager,
+        });
     }
 
     private static runRestartPackagerCommandAndUpdateStatus(project: IReactNativeProject): Q.Promise<void> {

--- a/src/extension/commandPaletteHandler.ts
+++ b/src/extension/commandPaletteHandler.ts
@@ -190,7 +190,7 @@ export class CommandPaletteHandler {
                 androidPlatform.showDevMenu()
                     .catch(() => { }); // Ignore any errors
                 const iosPlatform = <IOSPlatform>this.createPlatform(project, "ios", IOSPlatform);
-                iosPlatform.showDevMenu(project.workspaceFolder.uri.fsPath)
+                iosPlatform.showDevMenu()
                     .catch(() => { }); // Ignore any errors
                 return Q.resolve(void 0);
             });
@@ -203,7 +203,7 @@ export class CommandPaletteHandler {
                 androidPlatform.reloadApp()
                     .catch(() => { }); // Ignore any errors
                 const iosPlatform = <IOSPlatform>this.createPlatform(project, "ios", IOSPlatform);
-                iosPlatform.reloadApp(project.workspaceFolder.uri.fsPath)
+                iosPlatform.reloadApp()
                     .catch(() => { }); // Ignore any errors
                 return Q.resolve(void 0);
             });

--- a/src/extension/ios/iOSPlatform.ts
+++ b/src/extension/ios/iOSPlatform.ts
@@ -42,12 +42,12 @@ export class IOSPlatform extends GeneralMobilePlatform {
 
     private static RUN_IOS_SUCCESS_PATTERNS = ["BUILD SUCCEEDED"];
 
-    public static showDevMenu(fsPath: string, deviceId?: string): Q.Promise<void> {
-        return this.remote(fsPath).showDevMenu(deviceId);
+    public showDevMenu(fsPath: string, deviceId?: string): Q.Promise<void> {
+        return IOSPlatform.remote(fsPath).showDevMenu(deviceId);
     }
 
-    public static reloadApp(fsPath: string, deviceId?: string): Q.Promise<void> {
-        return this.remote(fsPath).reloadApp(deviceId);
+    public reloadApp(fsPath: string, deviceId?: string): Q.Promise<void> {
+        return IOSPlatform.remote(fsPath).reloadApp(deviceId);
     }
 
     constructor(protected runOptions: IIOSRunOptions, platformDeps: MobilePlatformDeps = {}) {

--- a/src/extension/ios/iOSPlatform.ts
+++ b/src/extension/ios/iOSPlatform.ts
@@ -42,12 +42,12 @@ export class IOSPlatform extends GeneralMobilePlatform {
 
     private static RUN_IOS_SUCCESS_PATTERNS = ["BUILD SUCCEEDED"];
 
-    public showDevMenu(fsPath: string, deviceId?: string): Q.Promise<void> {
-        return IOSPlatform.remote(fsPath).showDevMenu(deviceId);
+    public showDevMenu(deviceId?: string): Q.Promise<void> {
+        return IOSPlatform.remote(this.runOptions.projectRoot).showDevMenu(deviceId);
     }
 
-    public reloadApp(fsPath: string, deviceId?: string): Q.Promise<void> {
-        return IOSPlatform.remote(fsPath).reloadApp(deviceId);
+    public reloadApp(deviceId?: string): Q.Promise<void> {
+        return IOSPlatform.remote(this.runOptions.projectRoot).reloadApp(deviceId);
     }
 
     constructor(protected runOptions: IIOSRunOptions, platformDeps: MobilePlatformDeps = {}) {

--- a/test/extension/android/androidPlatform.test.ts
+++ b/test/extension/android/androidPlatform.test.ts
@@ -18,6 +18,7 @@ import * as rnHelper from "../../../src/common/reactNativeProjectHelper";
 import "should";
 import * as sinon from "sinon";
 import { SettingsHelper } from "../../../src/extension/settingsHelper";
+import { NullLogger } from "../../../src/extension/log/NullLogger";
 
 // TODO: Launch the extension server
 
@@ -36,6 +37,7 @@ suite("androidPlatform", function () {
         let androidPlatform: AndroidPlatform;
         let sandbox: Sinon.SinonSandbox;
         let devices: any;
+        let adbHelper: adb.AdbHelper;
 
         function createAndroidPlatform(runOptions: IAndroidRunOptions): AndroidPlatform {
             return new AndroidPlatform(runOptions);
@@ -61,7 +63,9 @@ suite("androidPlatform", function () {
                 return Q.resolve("0.0.1");
             });
 
-            sandbox.stub(adb.AdbHelper, "launchApp", function (projectRoot_: string, packageName: string, debugTarget?: string) {
+            adbHelper = new adb.AdbHelper("", new NullLogger());
+
+            sandbox.stub(adbHelper, "launchApp", function (projectRoot_: string, packageName: string, debugTarget?: string) {
                 devices = devices.map((device: any) => {
                     if (!debugTarget) {
                         device.installedApplications[androidPackageName] = { isInDebugMode: false };
@@ -76,20 +80,22 @@ suite("androidPlatform", function () {
 
                 return Q.resolve(void 0);
             });
-            sandbox.stub(adb.AdbHelper, "getConnectedDevices", function () {
+            sandbox.stub(adbHelper, "getConnectedDevices", function () {
                 return Q.resolve(devices);
             });
-            sandbox.stub(adb.AdbHelper, "getOnlineDevices", function () {
+            sandbox.stub(adbHelper, "getOnlineDevices", function () {
                 return Q.resolve(devices.filter((device: any) => {
                     return device.isOnline;
                 }));
             });
-            sandbox.stub(adb.AdbHelper, "apiVersion", function () {
+            sandbox.stub(adbHelper, "apiVersion", function () {
                 return Q.resolve(adb.AndroidAPILevel.LOLLIPOP);
             });
-            sandbox.stub(adb.AdbHelper, "reverseAdb", function () {
+            sandbox.stub(adbHelper, "reverseAdb", function () {
                 return Q.resolve(void 0);
             });
+
+            androidPlatform.setAdbHelper(adbHelper);
 
             sandbox.stub(reactNative, "installAppInDevice", function (deviceId: string) {
                 devices = devices.map((device: any)  => {

--- a/test/resources/reactNative022.ts
+++ b/test/resources/reactNative022.ts
@@ -50,7 +50,7 @@ export class ReactNative022 {
     private projectRoot: string;
     private androidAPKPath: string;
 
-    constructor(private fileSystem: FileSystem) {
+    constructor(private fileSystem: FileSystem, private adbHelper: AdbHelper) {
         assert(this.fileSystem, "fileSystem shouldn't be null");
     }
 
@@ -133,7 +133,7 @@ export class ReactNative022 {
     }
 
     private installAppInAllDevices(): Q.Promise<void> {
-        let devices = new AdbHelper(this.projectRoot).getConnectedDevices();
+        let devices = this.adbHelper.getConnectedDevices();
         return new PromiseUtil().reduce(devices, device => this.installAppInDevice(device.id));
     }
 
@@ -164,7 +164,7 @@ export class ReactNative022 {
         const matches = stdout.match(new RegExp(succesfulOutputEnd));
         if (matches) {
             if (matches.length === 3 && matches[1] === this.androidPackageName && matches[2] === this.androidPackageName) {
-                return new AdbHelper(this.projectRoot).launchApp(this.projectRoot, this.androidPackageName);
+                return this.adbHelper.launchApp(this.projectRoot, this.androidPackageName);
             } else {
                 return Q.reject<void>(new Error("There was an error while trying to match the Starting the app messages."
                     + "Expected to match the pattern and recognize the expected android package name, but it failed."

--- a/test/resources/reactNative022.ts
+++ b/test/resources/reactNative022.ts
@@ -14,7 +14,6 @@ import {Package} from "../../src/common/node/package";
 import {Recording, Simulator} from "./processExecution/simulator";
 import {AdbHelper} from "../../src/extension/android/adb";
 import {APKSerializer} from "./simulators/apkSerializer";
-import { NullLogger } from "../../src/extension/log/NullLogger";
 
 const sampleRNProjectPath = path.join(__dirname, "sampleReactNative022Project");
 const processExecutionsRecordingsPath = path.join(__dirname, "processExecutionsRecordings");
@@ -134,7 +133,7 @@ export class ReactNative022 {
     }
 
     private installAppInAllDevices(): Q.Promise<void> {
-        let devices = new AdbHelper("", new NullLogger()).getConnectedDevices();
+        let devices = new AdbHelper(this.projectRoot).getConnectedDevices();
         return new PromiseUtil().reduce(devices, device => this.installAppInDevice(device.id));
     }
 
@@ -165,7 +164,7 @@ export class ReactNative022 {
         const matches = stdout.match(new RegExp(succesfulOutputEnd));
         if (matches) {
             if (matches.length === 3 && matches[1] === this.androidPackageName && matches[2] === this.androidPackageName) {
-                return new AdbHelper("", new NullLogger()).launchApp(this.projectRoot, this.androidPackageName);
+                return new AdbHelper(this.projectRoot).launchApp(this.projectRoot, this.androidPackageName);
             } else {
                 return Q.reject<void>(new Error("There was an error while trying to match the Starting the app messages."
                     + "Expected to match the pattern and recognize the expected android package name, but it failed."

--- a/test/resources/reactNative022.ts
+++ b/test/resources/reactNative022.ts
@@ -14,6 +14,7 @@ import {Package} from "../../src/common/node/package";
 import {Recording, Simulator} from "./processExecution/simulator";
 import {AdbHelper} from "../../src/extension/android/adb";
 import {APKSerializer} from "./simulators/apkSerializer";
+import { NullLogger } from "../../src/extension/log/NullLogger";
 
 const sampleRNProjectPath = path.join(__dirname, "sampleReactNative022Project");
 const processExecutionsRecordingsPath = path.join(__dirname, "processExecutionsRecordings");
@@ -133,7 +134,7 @@ export class ReactNative022 {
     }
 
     private installAppInAllDevices(): Q.Promise<void> {
-        let devices = AdbHelper.getConnectedDevices();
+        let devices = new AdbHelper("", new NullLogger()).getConnectedDevices();
         return new PromiseUtil().reduce(devices, device => this.installAppInDevice(device.id));
     }
 
@@ -164,7 +165,7 @@ export class ReactNative022 {
         const matches = stdout.match(new RegExp(succesfulOutputEnd));
         if (matches) {
             if (matches.length === 3 && matches[1] === this.androidPackageName && matches[2] === this.androidPackageName) {
-                return AdbHelper.launchApp(this.projectRoot, this.androidPackageName);
+                return new AdbHelper("", new NullLogger()).launchApp(this.projectRoot, this.androidPackageName);
             } else {
                 return Q.reject<void>(new Error("There was an error while trying to match the Starting the app messages."
                     + "Expected to match the pattern and recognize the expected android package name, but it failed."


### PR DESCRIPTION
This PR add ability to use Android SDK location defined in `sdk.dir` at `android/local.properties` if exists.

Relates to #688.