### PR TITLE
Return spawn instead of fork

### DIFF
--- a/src/debugger/forkedAppWorker.ts
+++ b/src/debugger/forkedAppWorker.ts
@@ -77,6 +77,8 @@ export class ForkedAppWorker implements IDebuggeeWorker {
         // The adapter will continue execution once it's done with breakpoints.
         const nodeArgs = [`--inspect=${port}`, "--debug-brk", scriptToRunPath];
         // Start child Node process in debugging mode
+        // Using fork instead of spawn causes breakage of piping between app worker and VS Code debug console, e.g. console.log() in application
+        // wouldn't work. Please see https://github.com/Microsoft/vscode-react-native/issues/758
         this.debuggeeProcess = child_process.spawn("node", nodeArgs, {
             stdio: ["pipe", "pipe", "pipe", "ipc"],
         })

--- a/src/debugger/forkedAppWorker.ts
+++ b/src/debugger/forkedAppWorker.ts
@@ -75,9 +75,11 @@ export class ForkedAppWorker implements IDebuggeeWorker {
         // Note that we set --debug-brk flag to pause the process on the first line - this is
         // required for debug adapter to set the breakpoints BEFORE the debuggee has started.
         // The adapter will continue execution once it's done with breakpoints.
-        const nodeArgs = [`--inspect=${port}`, "--debug-brk"];
+        const nodeArgs = [`--inspect=${port}`, "--debug-brk", scriptToRunPath];
         // Start child Node process in debugging mode
-        this.debuggeeProcess = child_process.fork(scriptToRunPath, nodeArgs)
+        this.debuggeeProcess = child_process.spawn("node", nodeArgs, {
+            stdio: ["pipe", "pipe", "pipe", "ipc"],
+        })
         .on("message", (message: any) => {
             // 'workerLoaded' is a special message that indicates that worker is done with loading.
             // We need to wait for it before doing any IPC because process.send doesn't seems to care

--- a/test/debugger/appWorker.test.ts
+++ b/test/debugger/appWorker.test.ts
@@ -34,7 +34,7 @@ suite("appWorker", function () {
                     scriptBody, MultipleLifetimesAppWorker.WORKER_DONE, WORKER_DELAY_SHUTDOWN].join("\n");
 
                 spawnStub = sinon.stub(child_process, "spawn", () =>
-                    originalSpawn("node", ["-e", wrappedBody], { stdio: ["pipe", "pipe", "pipe", "ipc"] }))
+                    originalSpawn("node", ["-e", wrappedBody], { stdio: ["pipe", "pipe", "pipe", "ipc"] }));
 
                 testWorker = new ForkedAppWorker("localhost", packagerPort, sourcesStoragePath, "", postReplyFunction);
                 return testWorker;


### PR DESCRIPTION
Changes previously introduced in https://github.com/Microsoft/vscode-react-native/pull/760 breaks input/output channels between app worker and Debug Console, so this PR reverts them.