### PR TITLE
Update extension description

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -1,5 +1,5 @@
 {
-    "reactNative.description":"Code-hinting, debugging and integrated commands for React Native",
+    "reactNative.description":"Debugging and integrated commands for React Native",
     "reactNative.license":"SEE LICENSE IN LICENSE.txt",
     "reactNative.command.runAndroidSimulator.title":"Run Android on Simulator",
     "reactNative.command.runAndroidDevice.title":"Run Android on Device",


### PR DESCRIPTION
Extension doesn't provide code-hinting anymore for React Native so we should remove any mentions of it.