### PR TITLE
Fix "Run Android on Emulator" wording

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -1,7 +1,7 @@
 {
     "reactNative.description":"Debugging and integrated commands for React Native",
     "reactNative.license":"SEE LICENSE IN LICENSE.txt",
-    "reactNative.command.runAndroidSimulator.title":"Run Android on Simulator",
+    "reactNative.command.runAndroidSimulator.title":"Run Android on Emulator",
     "reactNative.command.runAndroidDevice.title":"Run Android on Device",
     "reactNative.command.runIosSimulator.title":"Run iOS on Simulator",
     "reactNative.command.runIosDevice.title":"Run iOS on Device",


### PR DESCRIPTION
Just a minor wording improvement, changing

```
Run Android on Simulator
```

to

```
Run Android on Emulator
```

**Reason**: [Android is using emulators](https://developer.android.com/studio/run/emulator), not simulators.

Even though it _sounds_ similar, the underlying mechanism is very different: On Android, a real image of the actual operating system is _emulated_ (like a virtual machine), whereas on iOS, the simulator _simulates_ the environment that an app would use on a real device.

This PR fixes the wording in the Command Palette.