### PR TITLE
[Smoke tests] Smoke test debugging improvement

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -203,6 +203,25 @@
             ],
             "sourceMaps": true,
             "preLaunchTask": "build-smoke-tests"
+        },
+        {
+			"type": "node",
+            "request": "launch",
+            "protocol": "inspector",
+			"name": "Launch Smoke Test (skip setup)",
+			"program": "${workspaceFolder}/test/smoke/node_modules/mocha/bin/_mocha",
+            "cwd": "${workspaceFolder}/test/smoke",
+            "args": [
+                "--dont-delete-vsix",
+                "--skip-setup"
+            ],
+            "timeout": 240000,
+            "stopOnEntry": false,
+			"outFiles": [
+				"${workspaceRoot}/src/**/*.js"
+            ],
+            "sourceMaps": true,
+            "preLaunchTask": "build-smoke-tests"
 		}
     ],
     "compounds": [

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -137,6 +137,10 @@ async function setup(): Promise<void> {
 }
 
 before(async function () {
+    if (process.argv.includes("--skip-setup")) {
+        console.log("*** --skip-setup parameter is set, skipping clean up and apps installation");
+        return;
+    }
     this.timeout(smokeTestsConstants.smokeTestSetupAwaitTimeout);
     setupEnvironmentHelper.cleanUp(path.join(testVSCodeExecutableFolder, ".."), [workspacePath, ExpoWorkspacePath]);
     try {


### PR DESCRIPTION
Add `--skip-setup` startup argument to skip tests setup