### PR TITLE
[Smoke tests] Tests refactoring, fix css selectors for VS Code 1.33

### DIFF
--- a/test/smoke/.gitignore
+++ b/test/smoke/.gitignore
@@ -10,3 +10,4 @@ test-results.xml
 resources/latestRNApp/**
 resources/latestExpoApp/**
 resources/pureRNExpoApp/**
+resources/.vscode-test/**

--- a/test/smoke/src/areas/debug/debug.ts
+++ b/test/smoke/src/areas/debug/debug.ts
@@ -12,11 +12,11 @@ const DEBUG_OPTIONS_COMBOBOX = "select[aria-label=\"Debug Launch Configurations\
 const DEBUG_OPTIONS_COMBOBOX_OPENED = `${DEBUG_OPTIONS_COMBOBOX}.monaco-select-box-dropdown-padding.synthetic-focus`;
 const CONFIGURE = `div[id="workbench.parts.sidebar"] .actions-container .configure`;
 const START = `.icon[title="Start Debugging"]`;
-const STOP = `.debug-toolbar .debug-action.stop`;
-const STEP_OVER = `.debug-toolbar .debug-action.step-over`;
-const STEP_IN = `.debug-toolbar .debug-action.step-into`;
-const STEP_OUT = `.debug-toolbar .debug-action.step-out`;
-const CONTINUE = `.debug-toolbar .debug-action.continue`;
+const STOP = `.debug-toolbar .action-label[title*=\"Stop\"]`;
+const STEP_OVER = `.debug-toolbar .action-label[title*=\"Step Over\"]`;
+const STEP_IN = `.debug-toolbar .action-label[title*=\"Step Into\"]`;
+const STEP_OUT = `.debug-toolbar .action-label[title*=\"Step Out\"]`;
+const CONTINUE = `.debug-toolbar .action-label[title*=\"Continue\"]`;
 const GLYPH_AREA = ".margin-view-overlays>:nth-child";
 const BREAKPOINT_GLYPH = ".debug-breakpoint";
 // const PAUSE = `.debug-toolbar .debug-action.pause`;

--- a/test/smoke/src/areas/explorer/explorer.ts
+++ b/test/smoke/src/areas/explorer/explorer.ts
@@ -23,7 +23,7 @@ export class Explorer extends Viewlet {
     }
 
     public async openFile(fileName: string): Promise<any> {
-        await this.spectron.client.doubleClickAndWait(`div[class="monaco-icon-label file-icon ${fileName.toLowerCase()}-name-file-icon ${this.getExtensionSelector(fileName.toLowerCase())} explorer-item"]`);
+        await this.spectron.client.doubleClickAndWait(`div[class*="monaco-icon-label file-icon ${fileName.toLowerCase()}-name-file-icon ${this.getExtensionSelector(fileName.toLowerCase())} explorer-item"]`);
         await this.spectron.workbench.waitForEditorFocus(fileName);
     }
 

--- a/test/smoke/src/debugAndroid.test.ts
+++ b/test/smoke/src/debugAndroid.test.ts
@@ -85,7 +85,7 @@ export function setup() {
             await app.workbench.selectTab("Expo QR Code");
             console.log("Android Expo Debug test: 'Expo QR Code' tab selected");
             let expoURL;
-            for (let retries = 0; retries < 10; retries++) {
+            for (let retries = 0; retries < 5; retries++) {
                 expoURL = await app.workbench.debug.prepareExpoURLToClipboard();
                 if (expoURL) break;
             }
@@ -141,7 +141,7 @@ export function setup() {
             await app.workbench.selectTab("Expo QR Code");
             console.log("Android pure RN Expo test: 'Expo QR Code' tab selected");
             let expoURL;
-            for (let retries = 0; retries < 10; retries++) {
+            for (let retries = 0; retries < 5; retries++) {
                 expoURL = await app.workbench.debug.prepareExpoURLToClipboard();
                 if (expoURL) break;
             }

--- a/test/smoke/src/debugAndroid.test.ts
+++ b/test/smoke/src/debugAndroid.test.ts
@@ -67,6 +67,7 @@ export function setup() {
             this.timeout(debugExpoTestTime);
             const app = this.app as SpectronApplication;
             await app.restart({workspaceOrFolder: ExpoWorkspacePath});
+            console.log(`Android Expo Debug test: VS Code is opened in ${ExpoWorkspacePath} directory`);
             await app.workbench.explorer.openExplorerView();
             await app.workbench.explorer.openFile("App.js");
             await app.runCommand("cursorTop");
@@ -118,6 +119,7 @@ export function setup() {
             this.timeout(debugExpoTestTime);
             const app = this.app as SpectronApplication;
             await app.restart({workspaceOrFolder: pureRNWorkspacePath});
+            console.log(`Android pure RN Expo test: VS Code is opened in ${pureRNWorkspacePath} directory`);
             await app.workbench.explorer.openExplorerView();
             await app.workbench.explorer.openFile("App.js");
             await app.runCommand("cursorTop");

--- a/test/smoke/src/debugAndroid.test.ts
+++ b/test/smoke/src/debugAndroid.test.ts
@@ -84,7 +84,11 @@ export function setup() {
             console.log("Android Expo Debug test: 'Expo QR Code' tab found");
             await app.workbench.selectTab("Expo QR Code");
             console.log("Android Expo Debug test: 'Expo QR Code' tab selected");
-            let expoURL = await app.workbench.debug.prepareExpoURLToClipboard();
+            let expoURL;
+            for (let retries = 0; retries < 10; retries++) {
+                expoURL = await app.workbench.debug.prepareExpoURLToClipboard();
+                if (expoURL) break;
+            }
             assert.notStrictEqual(expoURL, null, "Expo URL pattern is not found in the clipboard");
             expoURL = expoURL as string;
             const opts = appiumHelper.prepareAttachOptsForAndroidActivity(EXPO_APP_PACKAGE_NAME, EXPO_APP_ACTIVITY_NAME,
@@ -136,7 +140,11 @@ export function setup() {
             console.log("Android pure RN Expo test: 'Expo QR Code' tab found");
             await app.workbench.selectTab("Expo QR Code");
             console.log("Android pure RN Expo test: 'Expo QR Code' tab selected");
-            let expoURL = await app.workbench.debug.prepareExpoURLToClipboard();
+            let expoURL;
+            for (let retries = 0; retries < 10; retries++) {
+                expoURL = await app.workbench.debug.prepareExpoURLToClipboard();
+                if (expoURL) break;
+            }
             assert.notStrictEqual(expoURL, null, "Expo URL pattern is not found in the clipboard");
             expoURL = expoURL as string;
             const opts = appiumHelper.prepareAttachOptsForAndroidActivity(EXPO_APP_PACKAGE_NAME, EXPO_APP_ACTIVITY_NAME,

--- a/test/smoke/src/helpers/appiumHelper.ts
+++ b/test/smoke/src/helpers/appiumHelper.ts
@@ -133,7 +133,7 @@ export class appiumHelper {
             // https://facebook.github.io/react-native/docs/debugging#accessing-the-in-app-developer-menu
             const devMenuCallCommand = "adb shell input keyevent 82";
             cp.exec(devMenuCallCommand);
-            await sleep(1000);
+            await sleep(10 * 1000);
     }
 
     public static async reloadRNAppAndroid(client: WebdriverIO.Client<WebdriverIO.RawResult<null>> & WebdriverIO.RawResult<null>) {

--- a/test/smoke/src/helpers/setupEnvironmentHelper.ts
+++ b/test/smoke/src/helpers/setupEnvironmentHelper.ts
@@ -252,11 +252,15 @@ export async function sleep(time: number) {
     });
 }
 
-export function cleanUp(testVSCodeDirectory: string, workspacePaths: string[]) {
+export function cleanUp(testVSCodeDirectory: string, testLogsFolder: string, workspacePaths: string[]) {
     console.log("\n*** Clean up...");
     if (fs.existsSync(testVSCodeDirectory)) {
         console.log(`*** Deleting test VS Code directory: ${testVSCodeDirectory}`);
         rimraf.sync(testVSCodeDirectory);
+    }
+    if (fs.existsSync(testLogsFolder)) {
+        console.log(`*** Deleting test logs directory: ${testLogsFolder}`);
+        rimraf.sync(testLogsFolder);
     }
     workspacePaths.forEach(testAppFolder => {
         if (fs.existsSync(testAppFolder)) {

--- a/test/smoke/src/helpers/setupEnvironmentHelper.ts
+++ b/test/smoke/src/helpers/setupEnvironmentHelper.ts
@@ -252,15 +252,15 @@ export async function sleep(time: number) {
     });
 }
 
-export function cleanUp(testVSCodeDirectory: string, testLogsFolder: string, workspacePaths: string[]) {
+export function cleanUp(testVSCodeDirectory: string, testLogsDirectory: string, workspacePaths: string[]) {
     console.log("\n*** Clean up...");
     if (fs.existsSync(testVSCodeDirectory)) {
         console.log(`*** Deleting test VS Code directory: ${testVSCodeDirectory}`);
         rimraf.sync(testVSCodeDirectory);
     }
-    if (fs.existsSync(testLogsFolder)) {
-        console.log(`*** Deleting test logs directory: ${testLogsFolder}`);
-        rimraf.sync(testLogsFolder);
+    if (fs.existsSync(testLogsDirectory)) {
+        console.log(`*** Deleting test logs directory: ${testLogsDirectory}`);
+        rimraf.sync(testLogsDirectory);
     }
     workspacePaths.forEach(testAppFolder => {
         if (fs.existsSync(testAppFolder)) {

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -176,7 +176,7 @@ before(async function () {
         return;
     }
     this.timeout(smokeTestsConstants.smokeTestSetupAwaitTimeout);
-    setupEnvironmentHelper.cleanUp(path.join(testVSCodeDirectory, ".."), [RNworkspacePath, ExpoWorkspacePath, pureRNWorkspacePath]);
+    setupEnvironmentHelper.cleanUp(path.join(testVSCodeDirectory, ".."), artifactsPath,[RNworkspacePath, ExpoWorkspacePath, pureRNWorkspacePath]);
     try {
         await setup();
     } catch (err) {

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -68,9 +68,9 @@ const resourcesPath = path.join(__dirname, "..", "resources");
 const isInsiders = process.env.CODE_VERSION === "insiders";
 let testVSCodeDirectory;
 if (!isInsiders) {
-     testVSCodeDirectory = path.join(repoRoot, ".vscode-test", "stable");
+     testVSCodeDirectory = path.join(resourcesPath, ".vscode-test", "stable");
 } else {
-    testVSCodeDirectory = path.join(repoRoot, ".vscode-test", "insiders");
+    testVSCodeDirectory = path.join(resourcesPath, ".vscode-test", "insiders");
 }
 
 let electronExecutablePath: string;
@@ -112,8 +112,8 @@ const pureRNExpoApp = "pureRNExpoApp";
 export const pureRNWorkspacePath = path.join(resourcesPath, pureRNExpoApp);
 const pureRNWorkspaceFilePath = path.join(pureRNWorkspacePath, "App.js");
 
-const userDataDir = path.join(testVSCodeDirectory, "userTmpFolder");
 const artifactsPath = path.join(repoRoot, "SmokeTestLogs");
+const userDataDir = path.join(artifactsPath, "VSCodeUserData");
 
 const extensionsPath = path.join(testVSCodeDirectory, "extensions");
 

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -151,7 +151,7 @@ async function setup(): Promise<void> {
     setupEnvironmentHelper.prepareReactNativeApplication(pureRNWorkspaceFilePath, resourcesPath, pureRNWorkspacePath, pureRNExpoApp, latestRNVersionExpo);
     setupEnvironmentHelper.addExpoDependencyToRNProject(pureRNWorkspacePath);
     await setupEnvironmentHelper.installExpoAppOnAndroid(ExpoWorkspacePath);
-    await setupEnvironmentHelper.downloadVSCodeExecutable(repoRoot);
+    await setupEnvironmentHelper.downloadVSCodeExecutable(resourcesPath);
 
     electronExecutablePath = getBuildElectronPath(testVSCodeDirectory);
     if (!fs.existsSync(testVSCodeDirectory || "")) {

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -176,7 +176,7 @@ before(async function () {
         return;
     }
     this.timeout(smokeTestsConstants.smokeTestSetupAwaitTimeout);
-    setupEnvironmentHelper.cleanUp(path.join(testVSCodeDirectory, ".."), artifactsPath,[RNworkspacePath, ExpoWorkspacePath, pureRNWorkspacePath]);
+    setupEnvironmentHelper.cleanUp(path.join(testVSCodeDirectory, ".."), artifactsPath, [RNworkspacePath, ExpoWorkspacePath, pureRNWorkspacePath]);
     try {
         await setup();
     } catch (err) {

--- a/test/smoke/src/spectron/application.ts
+++ b/test/smoke/src/spectron/application.ts
@@ -10,6 +10,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as mkdirp from "mkdirp";
 import { sanitize } from "../helpers/utilities";
+import { sleep } from "../helpers/setupEnvironmentHelper";
 
 // Just hope random helps us here, cross your fingers!
 export async function findFreePort(): Promise<number> {
@@ -115,8 +116,9 @@ export class SpectronApplication {
 
     public async restart(options: { workspaceOrFolder?: string, extraArgs?: string[] }): Promise<any> {
         await this.stop();
-        await new Promise(c => setTimeout(c, 1000));
+        await sleep(1000);
         await this._start(options.workspaceOrFolder, options.extraArgs);
+        await sleep(5000);
     }
 
     public async reload(): Promise<any> {


### PR DESCRIPTION
Add VS Code temporary folder to artifacts folder
Replace drop-win/.gitkeep to correct folder
Add test logs folder to clean up
Fix css selectors for debugging panel due to VS Code 1.33 release
Add retries for expoURL get method
Increase timeout for opening React Native DevMenu for **all platforms**