### PR TITLE
Fix for node debugging process arguments due to end of life of --debug-brk arg in Node 12

### DIFF
--- a/src/debugger/forkedAppWorker.ts
+++ b/src/debugger/forkedAppWorker.ts
@@ -102,9 +102,6 @@ export class ForkedAppWorker implements IDebuggeeWorker {
         .on("error", (error: Error) => {
             printDebuggingError(ErrorHelper.getInternalError(InternalErrorCode.ReactNativeWorkerProcessThrownAnError), error);
         })
-        .on("close", () => {
-            console.log("debuggee process ended");
-        });
 
         // If special env variables are defined, then write process outputs to file
         this.logDirectory = getLoggingDirectory();

--- a/src/debugger/forkedAppWorker.ts
+++ b/src/debugger/forkedAppWorker.ts
@@ -77,10 +77,10 @@ export class ForkedAppWorker implements IDebuggeeWorker {
         let scriptToRunPath = path.resolve(this.sourcesStoragePath, ScriptImporter.DEBUGGER_WORKER_FILENAME);
         const port = Math.round(Math.random() * 40000 + 3000);
 
-        // Note that we set --debug-brk flag to pause the process on the first line - this is
+        // Note that we set --inspect-brk flag to pause the process on the first line - this is
         // required for debug adapter to set the breakpoints BEFORE the debuggee has started.
         // The adapter will continue execution once it's done with breakpoints.
-        const nodeArgs = [`--inspect=${port}`, "--debug-brk", scriptToRunPath];
+        const nodeArgs = [`--inspect-brk=${port}`, scriptToRunPath];
         // Start child Node process in debugging mode
         // Using fork instead of spawn causes breakage of piping between app worker and VS Code debug console, e.g. console.log() in application
         // wouldn't work. Please see https://github.com/Microsoft/vscode-react-native/issues/758
@@ -101,6 +101,9 @@ export class ForkedAppWorker implements IDebuggeeWorker {
         })
         .on("error", (error: Error) => {
             printDebuggingError(ErrorHelper.getInternalError(InternalErrorCode.ReactNativeWorkerProcessThrownAnError), error);
+        })
+        .on("close", () => {
+            console.log("debuggee process ended");
         });
 
         // If special env variables are defined, then write process outputs to file

--- a/src/debugger/forkedAppWorker.ts
+++ b/src/debugger/forkedAppWorker.ts
@@ -101,7 +101,7 @@ export class ForkedAppWorker implements IDebuggeeWorker {
         })
         .on("error", (error: Error) => {
             printDebuggingError(ErrorHelper.getInternalError(InternalErrorCode.ReactNativeWorkerProcessThrownAnError), error);
-        })
+        });
 
         // If special env variables are defined, then write process outputs to file
         this.logDirectory = getLoggingDirectory();


### PR DESCRIPTION
Fixes #1000 
[Node.js no more supports `--debug-brk` arg in Node.js 12](https://github.com/nodejs/node/releases/tag/v12.0.0)
[`--debug-brk` deprecated since `v7.7.0`](https://nodejs.org/en/docs/guides/debugging-getting-started/#legacy-debugger )
[AB#606](https://dev.azure.com/vscode-webdiag-extensions/5c2c3798-7e49-49f6-b45f-77d9c69636c6/_workitems/edit/606)