### PR TITLE
Add DebugConfigProvider for configuring initial debug configurations

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"url": "https://github.com/Microsoft/vscode-react-native"
 	},
 	"engines": {
-		"vscode": "^1.24.0"
+		"vscode": "^1.26.0"
 	},
 	"categories": [
 		"Debuggers",

--- a/package.json
+++ b/package.json
@@ -120,43 +120,6 @@
 						"typescriptreact"
 					]
 				},
-				"initialConfigurations": [
-					{
-						"name": "Debug Android",
-						"program": "${workspaceRoot}/.vscode/launchReactNative.js",
-						"type": "reactnative",
-						"request": "launch",
-						"platform": "android",
-						"sourceMaps": true,
-						"outDir": "${workspaceRoot}/.vscode/.react"
-					},
-					{
-						"name": "Debug iOS",
-						"program": "${workspaceRoot}/.vscode/launchReactNative.js",
-						"type": "reactnative",
-						"request": "launch",
-						"platform": "ios",
-						"sourceMaps": true,
-						"outDir": "${workspaceRoot}/.vscode/.react"
-					},
-					{
-						"name": "Attach to packager",
-						"program": "${workspaceRoot}/.vscode/launchReactNative.js",
-						"type": "reactnative",
-						"request": "attach",
-						"sourceMaps": true,
-						"outDir": "${workspaceRoot}/.vscode/.react"
-					},
-					{
-						"name": "Debug in Exponent",
-						"program": "${workspaceRoot}/.vscode/launchReactNative.js",
-						"type": "reactnative",
-						"request": "launch",
-						"platform": "exponent",
-						"sourceMaps": true,
-						"outDir": "${workspaceRoot}/.vscode/.react"
-					}
-				],
 				"configurationSnippets": [
 					{
 						"label": "React Native: Debug Android",

--- a/src/extension/debugConfigurationProvider.ts
+++ b/src/extension/debugConfigurationProvider.ts
@@ -73,10 +73,7 @@ export class ReactNativeDebugConfigProvider implements vscode.DebugConfiguration
 
             const pickHandler = () => {
                 let chosenConfigsEvent = TelemetryHelper.createTelemetryEvent("ChosenDebugConfigurations");
-                let selected: string[] = [];
-                configPicker.selectedItems.forEach((element) => {
-                    selected.push(element.label);
-                });
+                let selected: string[] = configPicker.selectedItems.map(element => element.label);
                 chosenConfigsEvent.properties["SelectedItems"] = selected;
                 Telemetry.send(chosenConfigsEvent);
                 const launchConfig = this.gatherDebugScenarios(selected);

--- a/src/extension/debugConfigurationProvider.ts
+++ b/src/extension/debugConfigurationProvider.ts
@@ -43,7 +43,8 @@ export class ReactNativeDebugConfigProvider implements vscode.DebugConfiguration
             "platform": "exponent",
             "sourceMaps": true,
             "outDir": "${workspaceRoot}/.vscode/.react",
-        }};
+        }
+    };
 
     private pickConfig: ReadonlyArray<vscode.QuickPickItem> = [
         {
@@ -85,8 +86,8 @@ export class ReactNativeDebugConfigProvider implements vscode.DebugConfiguration
             };
 
             disposables.push(
-            configPicker.onDidAccept(pickHandler),
-            configPicker.onDidHide(pickHandler)
+                configPicker.onDidAccept(pickHandler),
+                configPicker.onDidHide(pickHandler)
             );
 
         });

--- a/src/extension/debugConfigurationProvider.ts
+++ b/src/extension/debugConfigurationProvider.ts
@@ -78,13 +78,13 @@ export class ReactNativeDebugConfigProvider implements vscode.DebugConfiguration
                 Telemetry.send(chosenConfigsEvent);
                 const launchConfig = this.gatherDebugScenarios(selected);
                 disposables.forEach(d => d.dispose());
-                configPicker.dispose();
                 resolve(launchConfig);
             };
 
             disposables.push(
                 configPicker.onDidAccept(pickHandler),
-                configPicker.onDidHide(pickHandler)
+                configPicker.onDidHide(pickHandler),
+                configPicker
             );
 
         });
@@ -93,9 +93,7 @@ export class ReactNativeDebugConfigProvider implements vscode.DebugConfiguration
     private gatherDebugScenarios(selectedItems: string[]): vscode.DebugConfiguration[] {
         let launchConfig: vscode.DebugConfiguration[] = [];
         if (selectedItems) {
-            selectedItems.forEach(element => {
-                launchConfig.push(this.debugConfigurations[element]);
-            });
+            selectedItems.map(element => launchConfig.push(this.debugConfigurations[element]));
         }
         return launchConfig;
     }

--- a/src/extension/debugConfigurationProvider.ts
+++ b/src/extension/debugConfigurationProvider.ts
@@ -43,7 +43,7 @@ export class ReactNativeDebugConfigProvider implements vscode.DebugConfiguration
             "platform": "exponent",
             "sourceMaps": true,
             "outDir": "${workspaceRoot}/.vscode/.react",
-        }
+        },
     };
 
     private pickConfig: ReadonlyArray<vscode.QuickPickItem> = [

--- a/src/extension/debugConfigurationProvider.ts
+++ b/src/extension/debugConfigurationProvider.ts
@@ -66,10 +66,11 @@ export class ReactNativeDebugConfigProvider implements vscode.DebugConfiguration
     ];
 
     public async provideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration[]> {
-        const configPicker = this.prepareDebugConfigPicker();
-        configPicker.show();
-        const disposables: vscode.Disposable[] = [];
         return new Promise<vscode.DebugConfiguration[]>((resolve) => {
+            const configPicker = this.prepareDebugConfigPicker();
+            configPicker.show();
+            const disposables: vscode.Disposable[] = [];
+
             const pickHandler = () => {
                 let chosenConfigsEvent = TelemetryHelper.createTelemetryEvent("ChosenDebugConfigurations");
                 let selected: string[] = [];
@@ -109,6 +110,7 @@ export class ReactNativeDebugConfigProvider implements vscode.DebugConfiguration
         debugConfigPicker.ignoreFocusOut = true;
         debugConfigPicker.title = localize("DebugConfigQuickPickLabel", "Pick debug configurations");
         debugConfigPicker.items = this.pickConfig;
+        // QuickPickItem property `picked` doesn't work, so this line will check first item in the list
         debugConfigPicker.selectedItems = [this.pickConfig[0]];
         return debugConfigPicker;
     }

--- a/src/extension/debugConfigurationProvider.ts
+++ b/src/extension/debugConfigurationProvider.ts
@@ -94,9 +94,8 @@ export class ReactNativeDebugConfigProvider implements vscode.DebugConfiguration
 
     private gatherDebugScenarios(selectedItems: string[]): vscode.DebugConfiguration[] {
         let launchConfig: vscode.DebugConfiguration[] = [];
-        const pickedConfigs = selectedItems;
-        if (pickedConfigs) {
-            pickedConfigs.forEach(element => {
+        if (selectedItems) {
+            selectedItems.forEach(element => {
                 launchConfig.push(this.debugConfigurations[element]);
             });
         }

--- a/src/extension/debugConfigurationProvider.ts
+++ b/src/extension/debugConfigurationProvider.ts
@@ -4,6 +4,8 @@
 import * as vscode from "vscode";
 import { TelemetryHelper } from "../common/telemetryHelper";
 import { Telemetry } from "../common/telemetry";
+import * as nls from "vscode-nls";
+const localize = nls.loadMessageBundle();
 
 export class ReactNativeDebugConfigProvider implements vscode.DebugConfigurationProvider {
     private debugConfigurations = {
@@ -46,20 +48,20 @@ export class ReactNativeDebugConfigProvider implements vscode.DebugConfiguration
         private pickConfig: ReadonlyArray<vscode.QuickPickItem> = [
             {
                 label: "Debug Android",
-                description: "Debug React Native Android apps",
+                description: localize("DebugAndroidConfigDesc", "Debug React Native Android apps"),
                 picked: true,
             },
             {
                 label: "Debug iOS",
-                description: "Debug React Native iOS apps",
+                description: localize("DebugiOSConfigDesc", "Debug React Native iOS apps"),
             },
             {
                 label: "Attach to packager",
-                description: "Attach React Native debugger to already working application packager",
+                description: localize("AttachToPackagerConfigDesc", "Attach React Native debugger to already working application packager"),
             },
             {
                 label: "Debug in Exponent",
-                description: "Debug through Expo",
+                description: localize("DebugExpoConfigDesc", "Debug with Expo"),
             },
         ];
 
@@ -99,7 +101,7 @@ export class ReactNativeDebugConfigProvider implements vscode.DebugConfiguration
         const debugConfigPicker = vscode.window.createQuickPick();
         debugConfigPicker.canSelectMany = true;
         debugConfigPicker.ignoreFocusOut = true;
-        debugConfigPicker.title = "Pick debug configurations";
+        debugConfigPicker.title = localize("DebugConfigQuickPickLabel", "Pick debug configurations");
         debugConfigPicker.items = this.pickConfig;
         debugConfigPicker.selectedItems = [this.pickConfig[0]];
         return debugConfigPicker;

--- a/src/extension/debugConfigurationProvider.ts
+++ b/src/extension/debugConfigurationProvider.ts
@@ -91,10 +91,7 @@ export class ReactNativeDebugConfigProvider implements vscode.DebugConfiguration
     }
 
     private gatherDebugScenarios(selectedItems: string[]): vscode.DebugConfiguration[] {
-        let launchConfig: vscode.DebugConfiguration[] = [];
-        if (selectedItems) {
-            selectedItems.map(element => launchConfig.push(this.debugConfigurations[element]));
-        }
+        let launchConfig: vscode.DebugConfiguration[] = selectedItems.map(element => this.debugConfigurations[element]);
         return launchConfig;
     }
 

--- a/src/extension/debugConfigurationProvider.ts
+++ b/src/extension/debugConfigurationProvider.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+import * as vscode from "vscode";
+
+export class ReactNativeDebugConfigProvider implements vscode.DebugConfigurationProvider {
+
+    public configurations = {
+    "Debug Android": {
+        "name": "Debug Android",
+        "program": "${workspaceRoot}/.vscode/launchReactNative.js",
+        "type": "reactnative",
+        "request": "launch",
+        "platform": "android",
+        "sourceMaps": true,
+        "outDir": "${workspaceRoot}/.vscode/.react",
+    },
+    "Debug iOS": {
+        "name": "Debug iOS",
+        "program": "${workspaceRoot}/.vscode/launchReactNative.js",
+        "type": "reactnative",
+        "request": "launch",
+        "platform": "ios",
+        "sourceMaps": true,
+        "outDir": "${workspaceRoot}/.vscode/.react",
+    },
+    "Attach to packager": {
+        "name": "Attach to packager",
+        "program": "${workspaceRoot}/.vscode/launchReactNative.js",
+        "type": "reactnative",
+        "request": "attach",
+        "sourceMaps": true,
+        "outDir": "${workspaceRoot}/.vscode/.react",
+    },
+    "Debug in Exponent": {
+        "name": "Debug in Exponent",
+        "program": "${workspaceRoot}/.vscode/launchReactNative.js",
+        "type": "reactnative",
+        "request": "launch",
+        "platform": "exponent",
+        "sourceMaps": true,
+        "outDir": "${workspaceRoot}/.vscode/.react",
+    }};
+
+    public async provideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration[]> {
+        const pickedConfigs = await vscode.window.showQuickPick(["Debug Android", "Debug iOS", "Attach to packager", "Debug in Exponent"], {canPickMany: true}, token);
+        let launchConfig: vscode.DebugConfiguration[] = [];
+        if (pickedConfigs) {
+
+            pickedConfigs.forEach(element => {
+                launchConfig.push(this.configurations[element]);
+            });
+        }
+
+        return launchConfig;
+    }
+}

--- a/src/extension/debugConfigurationProvider.ts
+++ b/src/extension/debugConfigurationProvider.ts
@@ -48,24 +48,20 @@ export class ReactNativeDebugConfigProvider implements vscode.DebugConfiguration
     private pickConfig: ReadonlyArray<vscode.QuickPickItem> = [
         {
             label: "Debug Android",
-            description: localize("DebugAndroidConfigDesc", "Debug React Native Android apps"),
-            detail: localize("DebugAndroidConfigDesc", "Debug React Native Android apps"),
+            description: localize("DebugAndroidConfigDesc", "Run and debug Android application"),
             picked: true,
         },
         {
             label: "Debug iOS",
-            description: localize("DebugiOSConfigDesc", "Debug React Native iOS apps"),
-            detail: localize("DebugiOSConfigDesc", "Debug React Native iOS apps"),
+            description: localize("DebugiOSConfigDesc", "Run and debug iOS application"),
         },
         {
             label: "Attach to packager",
-            description: localize("AttachToPackagerConfigDesc", "Attach React Native debugger to already working application packager"),
-            detail: localize("AttachToPackagerConfigDesc", "Attach React Native debugger to already working application packager"),
+            description: localize("AttachToPackagerConfigDesc", "Attach to already working application packager"),
         },
         {
             label: "Debug in Exponent",
-            description: localize("DebugExpoConfigDesc", "Debug with Expo"),
-            detail: localize("DebugExpoConfigDesc", "Debug with Expo"),
+            description: localize("DebugExpoConfigDesc", "Debug Expo application or React Native application in Expo"),
         },
     ];
 

--- a/src/extension/debugConfigurationProvider.ts
+++ b/src/extension/debugConfigurationProvider.ts
@@ -49,7 +49,6 @@ export class ReactNativeDebugConfigProvider implements vscode.DebugConfiguration
         {
             label: "Debug Android",
             description: localize("DebugAndroidConfigDesc", "Run and debug Android application"),
-            picked: true,
         },
         {
             label: "Debug iOS",

--- a/src/extension/debugConfigurationProvider.ts
+++ b/src/extension/debugConfigurationProvider.ts
@@ -45,29 +45,34 @@ export class ReactNativeDebugConfigProvider implements vscode.DebugConfiguration
             "outDir": "${workspaceRoot}/.vscode/.react",
         }};
 
-        private pickConfig: ReadonlyArray<vscode.QuickPickItem> = [
-            {
-                label: "Debug Android",
-                description: localize("DebugAndroidConfigDesc", "Debug React Native Android apps"),
-                picked: true,
-            },
-            {
-                label: "Debug iOS",
-                description: localize("DebugiOSConfigDesc", "Debug React Native iOS apps"),
-            },
-            {
-                label: "Attach to packager",
-                description: localize("AttachToPackagerConfigDesc", "Attach React Native debugger to already working application packager"),
-            },
-            {
-                label: "Debug in Exponent",
-                description: localize("DebugExpoConfigDesc", "Debug with Expo"),
-            },
-        ];
+    private pickConfig: ReadonlyArray<vscode.QuickPickItem> = [
+        {
+            label: "Debug Android",
+            description: localize("DebugAndroidConfigDesc", "Debug React Native Android apps"),
+            detail: localize("DebugAndroidConfigDesc", "Debug React Native Android apps"),
+            picked: true,
+        },
+        {
+            label: "Debug iOS",
+            description: localize("DebugiOSConfigDesc", "Debug React Native iOS apps"),
+            detail: localize("DebugiOSConfigDesc", "Debug React Native iOS apps"),
+        },
+        {
+            label: "Attach to packager",
+            description: localize("AttachToPackagerConfigDesc", "Attach React Native debugger to already working application packager"),
+            detail: localize("AttachToPackagerConfigDesc", "Attach React Native debugger to already working application packager"),
+        },
+        {
+            label: "Debug in Exponent",
+            description: localize("DebugExpoConfigDesc", "Debug with Expo"),
+            detail: localize("DebugExpoConfigDesc", "Debug with Expo"),
+        },
+    ];
 
     public async provideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration[]> {
         const configPicker = this.prepareDebugConfigPicker();
         configPicker.show();
+        const disposables: vscode.Disposable[] = [];
         return new Promise<vscode.DebugConfiguration[]>((resolve) => {
             const pickHandler = () => {
                 let chosenConfigsEvent = TelemetryHelper.createTelemetryEvent("ChosenDebugConfigurations");
@@ -75,14 +80,19 @@ export class ReactNativeDebugConfigProvider implements vscode.DebugConfiguration
                 configPicker.selectedItems.forEach((element) => {
                     selected.push(element.label);
                 });
-                chosenConfigsEvent.properties["config"] = selected;
+                chosenConfigsEvent.properties["SelectedItems"] = selected;
                 Telemetry.send(chosenConfigsEvent);
                 const launchConfig = this.gatherDebugScenarios(selected);
+                disposables.forEach(d => d.dispose());
                 configPicker.dispose();
                 resolve(launchConfig);
             };
-            configPicker.onDidAccept(pickHandler);
-            configPicker.onDidHide(pickHandler);
+
+            disposables.push(
+            configPicker.onDidAccept(pickHandler),
+            configPicker.onDidHide(pickHandler)
+            );
+
         });
     }
 

--- a/src/extension/debugConfigurationProvider.ts
+++ b/src/extension/debugConfigurationProvider.ts
@@ -6,41 +6,41 @@ import * as vscode from "vscode";
 export class ReactNativeDebugConfigProvider implements vscode.DebugConfigurationProvider {
 
     public configurations = {
-    "Debug Android": {
-        "name": "Debug Android",
-        "program": "${workspaceRoot}/.vscode/launchReactNative.js",
-        "type": "reactnative",
-        "request": "launch",
-        "platform": "android",
-        "sourceMaps": true,
-        "outDir": "${workspaceRoot}/.vscode/.react",
-    },
-    "Debug iOS": {
-        "name": "Debug iOS",
-        "program": "${workspaceRoot}/.vscode/launchReactNative.js",
-        "type": "reactnative",
-        "request": "launch",
-        "platform": "ios",
-        "sourceMaps": true,
-        "outDir": "${workspaceRoot}/.vscode/.react",
-    },
-    "Attach to packager": {
-        "name": "Attach to packager",
-        "program": "${workspaceRoot}/.vscode/launchReactNative.js",
-        "type": "reactnative",
-        "request": "attach",
-        "sourceMaps": true,
-        "outDir": "${workspaceRoot}/.vscode/.react",
-    },
-    "Debug in Exponent": {
-        "name": "Debug in Exponent",
-        "program": "${workspaceRoot}/.vscode/launchReactNative.js",
-        "type": "reactnative",
-        "request": "launch",
-        "platform": "exponent",
-        "sourceMaps": true,
-        "outDir": "${workspaceRoot}/.vscode/.react",
-    }};
+        "Debug Android": {
+            "name": "Debug Android",
+            "program": "${workspaceRoot}/.vscode/launchReactNative.js",
+            "type": "reactnative",
+            "request": "launch",
+            "platform": "android",
+            "sourceMaps": true,
+            "outDir": "${workspaceRoot}/.vscode/.react",
+        },
+        "Debug iOS": {
+            "name": "Debug iOS",
+            "program": "${workspaceRoot}/.vscode/launchReactNative.js",
+            "type": "reactnative",
+            "request": "launch",
+            "platform": "ios",
+            "sourceMaps": true,
+            "outDir": "${workspaceRoot}/.vscode/.react",
+        },
+        "Attach to packager": {
+            "name": "Attach to packager",
+            "program": "${workspaceRoot}/.vscode/launchReactNative.js",
+            "type": "reactnative",
+            "request": "attach",
+            "sourceMaps": true,
+            "outDir": "${workspaceRoot}/.vscode/.react",
+        },
+        "Debug in Exponent": {
+            "name": "Debug in Exponent",
+            "program": "${workspaceRoot}/.vscode/launchReactNative.js",
+            "type": "reactnative",
+            "request": "launch",
+            "platform": "exponent",
+            "sourceMaps": true,
+            "outDir": "${workspaceRoot}/.vscode/.react",
+        }};
 
     public async provideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration[]> {
         const pickedConfigs = await vscode.window.showQuickPick(["Debug Android", "Debug iOS", "Attach to packager", "Debug in Exponent"], {canPickMany: true}, token);

--- a/src/extension/debugConfigurationProvider.ts
+++ b/src/extension/debugConfigurationProvider.ts
@@ -68,9 +68,7 @@ export class ReactNativeDebugConfigProvider implements vscode.DebugConfiguration
     public async provideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration[]> {
         return new Promise<vscode.DebugConfiguration[]>((resolve) => {
             const configPicker = this.prepareDebugConfigPicker();
-            configPicker.show();
             const disposables: vscode.Disposable[] = [];
-
             const pickHandler = () => {
                 let chosenConfigsEvent = TelemetryHelper.createTelemetryEvent("ChosenDebugConfigurations");
                 let selected: string[] = configPicker.selectedItems.map(element => element.label);
@@ -87,6 +85,7 @@ export class ReactNativeDebugConfigProvider implements vscode.DebugConfiguration
                 configPicker
             );
 
+            configPicker.show();
         });
     }
 

--- a/src/extension/rn-extension.ts
+++ b/src/extension/rn-extension.ts
@@ -39,6 +39,7 @@ const localize = nls.loadMessageBundle();
 const outputChannelLogger = OutputChannelLogger.getMainChannel();
 const entryPointHandler = new EntryPointHandler(ProcessType.Extension, outputChannelLogger);
 const fsUtil = new FileSystem();
+let debugConfigProvider: vscode.Disposable;
 
 const APP_NAME = "react-native-tools";
 
@@ -65,7 +66,8 @@ export function activate(context: vscode.ExtensionContext): Q.Promise<void> {
         context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders((event) => onChangeWorkspaceFolders(context, event)));
         context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((event) => onChangeConfiguration(context)));
 
-        vscode.debug.registerDebugConfigurationProvider("reactnative", configProvider);
+        debugConfigProvider = vscode.debug.registerDebugConfigurationProvider("reactnative", configProvider);
+
         let activateExtensionEvent = TelemetryHelper.createTelemetryEvent("activate");
         Telemetry.send(activateExtensionEvent);
 
@@ -92,6 +94,7 @@ export function deactivate(): Q.Promise<void> {
         entryPointHandler.runFunction("extension.deactivate",
             ErrorHelper.getInternalError(InternalErrorCode.FailedToStopPackagerOnExit),
             () => {
+                debugConfigProvider.dispose();
                 CommandPaletteHandler.stopAllPackagers()
                 .then(() => {
                     return CommandPaletteHandler.stopElementInspector();

--- a/src/extension/rn-extension.ts
+++ b/src/extension/rn-extension.ts
@@ -32,6 +32,7 @@ import {ExtensionServer} from "./extensionServer";
 import {OutputChannelLogger} from "./log/OutputChannelLogger";
 import {ExponentHelper} from "./exponent/exponentHelper";
 import * as nls from "vscode-nls";
+import { ReactNativeDebugConfigProvider } from "./debugConfigurationProvider";
 const localize = nls.loadMessageBundle();
 
 /* all components use the same packager instance */
@@ -51,6 +52,7 @@ export function activate(context: vscode.ExtensionContext): Q.Promise<void> {
     outputChannelLogger.debug(`Extension version: ${appVersion}`);
     const ExtensionTelemetryReporter = require("vscode-extension-telemetry").default;
     const reporter = new ExtensionTelemetryReporter(APP_NAME, appVersion, Telemetry.APPINSIGHTS_INSTRUMENTATIONKEY);
+    const configProvider = new ReactNativeDebugConfigProvider();
     const workspaceFolders: vscode.WorkspaceFolder[] | undefined = vscode.workspace.workspaceFolders;
     let extProps: ICommandTelemetryProperties = {};
     if (workspaceFolders) {
@@ -62,6 +64,8 @@ export function activate(context: vscode.ExtensionContext): Q.Promise<void> {
     return entryPointHandler.runApp(APP_NAME, appVersion, ErrorHelper.getInternalError(InternalErrorCode.ExtensionActivationFailed), reporter, function activateRunApp() {
         context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders((event) => onChangeWorkspaceFolders(context, event)));
         context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((event) => onChangeConfiguration(context)));
+
+        vscode.debug.registerDebugConfigurationProvider("reactnative", configProvider);
 
         let activateExtensionEvent = TelemetryHelper.createTelemetryEvent("activate");
         Telemetry.send(activateExtensionEvent);

--- a/src/extension/rn-extension.ts
+++ b/src/extension/rn-extension.ts
@@ -31,8 +31,8 @@ import {TelemetryHelper, ICommandTelemetryProperties} from "../common/telemetryH
 import {ExtensionServer} from "./extensionServer";
 import {OutputChannelLogger} from "./log/OutputChannelLogger";
 import {ExponentHelper} from "./exponent/exponentHelper";
-import * as nls from "vscode-nls";
 import { ReactNativeDebugConfigProvider } from "./debugConfigurationProvider";
+import * as nls from "vscode-nls";
 const localize = nls.loadMessageBundle();
 
 /* all components use the same packager instance */
@@ -66,7 +66,6 @@ export function activate(context: vscode.ExtensionContext): Q.Promise<void> {
         context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((event) => onChangeConfiguration(context)));
 
         vscode.debug.registerDebugConfigurationProvider("reactnative", configProvider);
-
         let activateExtensionEvent = TelemetryHelper.createTelemetryEvent("activate");
         Telemetry.send(activateExtensionEvent);
 


### PR DESCRIPTION
This PR implements the first part of #830
Initial configurations in `package.json` are replaced by DebugConfigProvider class with using QuickPick UI to pick needed debug configurations. 
Required VS Code version is bumped to 1.26
Preview of how it looks: 
![DebugConfig](https://user-images.githubusercontent.com/32372875/60024879-4602cb00-96a1-11e9-9f37-2e1c93968ae3.gif)
[AB#683](https://dev.azure.com/vscode-webdiag-extensions/5c2c3798-7e49-49f6-b45f-77d9c69636c6/_workitems/edit/683)