### PR TITLE
Simplify basic debug scenarios

### DIFF
--- a/doc/debugging.md
+++ b/doc/debugging.md
@@ -51,9 +51,7 @@ For UWP apps use `windows` target platform in `launch.json` configuration, e.g.:
     "program": "${workspaceRoot}/.vscode/launchReactNative.js",
     "type": "reactnative",
     "request": "launch",
-    "platform": "windows",
-    "sourceMaps": true,
-    "outDir": "${workspaceRoot}/.vscode/.react"
+    "platform": "windows"
 }
 ```
 
@@ -65,8 +63,6 @@ For WPF apps use `wpf`, e.g.(WPF debugging available only for react-native-windo
     "program": "${workspaceRoot}/.vscode/launchReactNative.js",
     "type": "reactnative",
     "request": "launch",
-    "platform": "wpf",
-    "sourceMaps": true,
-    "outDir": "${workspaceRoot}/.vscode/.react"
+    "platform": "wpf"
 }
 ```

--- a/package.json
+++ b/package.json
@@ -129,8 +129,7 @@
 							"program": "^\"\\${workspaceRoot}/.vscode/launchReactNative.js\"",
 							"type": "reactnative",
 							"request": "launch",
-							"platform": "android",
-							"outDir": "^\"\\${workspaceRoot}/.vscode/.react\""
+							"platform": "android"
 						}
 					},
 					{
@@ -141,8 +140,7 @@
 							"program": "^\"\\${workspaceRoot}/.vscode/launchReactNative.js\"",
 							"type": "reactnative",
 							"request": "launch",
-							"platform": "ios",
-							"outDir": "^\"\\${workspaceRoot}/.vscode/.react\""
+							"platform": "ios"
 						}
 					},
 					{
@@ -152,8 +150,7 @@
 							"name": "Attach to packager",
 							"program": "^\"\\${workspaceRoot}/.vscode/launchReactNative.js\"",
 							"type": "reactnative",
-							"request": "attach",
-							"outDir": "^\"\\${workspaceRoot}/.vscode/.react\""
+							"request": "attach"
 						}
 					},
 					{
@@ -164,8 +161,7 @@
 							"program": "^\"\\${workspaceRoot}/.vscode/launchReactNative.js\"",
 							"type": "reactnative",
 							"request": "launch",
-							"platform": "exponent",
-							"outDir": "^\"\\${workspaceRoot}/.vscode/.react\""
+							"platform": "exponent"
 						}
 					}
 				],
@@ -183,11 +179,6 @@
 								"type": "boolean",
 								"description": "%reactNative.attach.sourceMaps.description%",
 								"default": false
-							},
-							"outDir": {
-								"type": "string",
-								"description": "%reactNative.attach.outDir.description%",
-								"default": null
 							},
 							"sourceMapPathOverrides": {
 								"type": "object",
@@ -290,11 +281,6 @@
 									"ReactNative:V",
 									"ReactNativeJS:V"
 								]
-							},
-							"outDir": {
-								"type": "string",
-								"description": "%reactNative.launch.outDir.description%",
-								"default": null
 							},
 							"runArguments": {
 								"type": "array",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,6 @@
 							"type": "reactnative",
 							"request": "launch",
 							"platform": "android",
-							"sourceMaps": true,
 							"outDir": "^\"\\${workspaceRoot}/.vscode/.react\""
 						}
 					},
@@ -143,7 +142,6 @@
 							"type": "reactnative",
 							"request": "launch",
 							"platform": "ios",
-							"sourceMaps": true,
 							"outDir": "^\"\\${workspaceRoot}/.vscode/.react\""
 						}
 					},
@@ -155,7 +153,6 @@
 							"program": "^\"\\${workspaceRoot}/.vscode/launchReactNative.js\"",
 							"type": "reactnative",
 							"request": "attach",
-							"sourceMaps": true,
 							"outDir": "^\"\\${workspaceRoot}/.vscode/.react\""
 						}
 					},
@@ -168,7 +165,6 @@
 							"type": "reactnative",
 							"request": "launch",
 							"platform": "exponent",
-							"sourceMaps": true,
 							"outDir": "^\"\\${workspaceRoot}/.vscode/.react\""
 						}
 					}

--- a/package.nls.json
+++ b/package.nls.json
@@ -19,7 +19,6 @@
     "reactNative.snippets.debugExpo.description":"A new configuration for launching Expo app",
     "reactNative.attach.program.description":"The path to launchReactNative.js in the vscode folder",
     "reactNative.attach.sourceMaps.description":"Whether to use JavaScript source maps to map the generated bundled code back to its original sources",
-    "reactNative.attach.outDir.description":"The location of the generated JavaScript code (the bundle file). Normally this should be \"${workspaceRoot}/.vscode/.react\"",
     "reactNative.attach.sourceMapsPathOverrides.description":"A set of mappings for rewriting the locations of source files from what the source map says, to their locations on disk. See https://github.com/Microsoft/vscode-react-native/blob/master/doc/debugging.md#debugging-with-typescript-and-haul for details",
     "reactNative.attach.trace.description":"Setup logging level in debugger.",
     "reactNative.attach.address.description":"TCP/IP address of debug port. Default is 'localhost'.",

--- a/src/common/remoteExtension.ts
+++ b/src/common/remoteExtension.ts
@@ -19,7 +19,7 @@ export interface IExtensionApi extends ICommonApi {
     stopMonitoringLogcat(): Q.Promise<void>;
     sendTelemetry(telemetryRequest: Telemetry.TelemetryRequest): Q.Promise<any>;
     openFileAtLocation(openFileRequest: OpenFileRequest): Q.Promise<void>;
-    getPackagerPort(program: string): Q.Promise<number>;
+    getPackagerPort(): Q.Promise<number>;
     showInformationMessage(infoMessage: string): Q.Promise<void>;
     launch(request: any): Q.Promise<any>;
     showDevMenu(deviceId?: string): Q.Promise<any>;
@@ -80,8 +80,8 @@ export class RemoteExtension {
         return this._api.Extension.openFileAtLocation(request);
     }
 
-    public getPackagerPort(program: string): Q.Promise<number> {
-        return this._api.Extension.getPackagerPort(program);
+    public getPackagerPort(): Q.Promise<number> {
+        return this._api.Extension.getPackagerPort();
     }
 
     public showInformationMessage(infoMessage: string): Q.Promise<void> {

--- a/src/common/remoteExtension.ts
+++ b/src/common/remoteExtension.ts
@@ -19,7 +19,7 @@ export interface IExtensionApi extends ICommonApi {
     stopMonitoringLogcat(): Q.Promise<void>;
     sendTelemetry(telemetryRequest: Telemetry.TelemetryRequest): Q.Promise<any>;
     openFileAtLocation(openFileRequest: OpenFileRequest): Q.Promise<void>;
-    getPackagerPort(): Q.Promise<number>;
+    getPackagerPort(program: string): Q.Promise<number>;
     showInformationMessage(infoMessage: string): Q.Promise<void>;
     launch(request: any): Q.Promise<any>;
     showDevMenu(deviceId?: string): Q.Promise<any>;
@@ -80,8 +80,8 @@ export class RemoteExtension {
         return this._api.Extension.openFileAtLocation(request);
     }
 
-    public getPackagerPort(): Q.Promise<number> {
-        return this._api.Extension.getPackagerPort();
+    public getPackagerPort(program: string): Q.Promise<number> {
+        return this._api.Extension.getPackagerPort(program);
     }
 
     public showInformationMessage(infoMessage: string): Q.Promise<void> {

--- a/src/debugger/nodeDebugWrapper.ts
+++ b/src/debugger/nodeDebugWrapper.ts
@@ -84,7 +84,7 @@ export function makeSession(
                     return this.remoteExtension.launch(request);
                 })
                 .then(() => {
-                    return this.remoteExtension.getPackagerPort(request.arguments.program);
+                    return this.remoteExtension.getPackagerPort();
                 })
                 .then((packagerPort: number) => {
                     this.attachRequest({
@@ -104,7 +104,7 @@ export function makeSession(
             this.requestSetup(request.arguments)
                 .then(() => {
                     logger.verbose(`Handle attach request: ${JSON.stringify(request.arguments, null , 2)}`);
-                    return this.remoteExtension.getPackagerPort(request.arguments.program);
+                    return this.remoteExtension.getPackagerPort();
                 })
                 .then((packagerPort: number) => {
                     this.attachRequest({
@@ -150,6 +150,9 @@ export function makeSession(
                 logger.setup(Logger.LogLevel.Log, chromeDebugCoreLogs || false);
             }
 
+            if (!args.sourceMaps) {
+                args.sourceMaps = true;
+            }
             const projectRootPath = getProjectRoot(args);
             return ReactNativeProjectHelper.isReactNativeProject(projectRootPath)
                 .then((result) => {

--- a/src/debugger/nodeDebugWrapper.ts
+++ b/src/debugger/nodeDebugWrapper.ts
@@ -84,7 +84,7 @@ export function makeSession(
                     return this.remoteExtension.launch(request);
                 })
                 .then(() => {
-                    return this.remoteExtension.getPackagerPort();
+                    return this.remoteExtension.getPackagerPort(request.arguments.program);
                 })
                 .then((packagerPort: number) => {
                     this.attachRequest({
@@ -104,7 +104,7 @@ export function makeSession(
             this.requestSetup(request.arguments)
                 .then(() => {
                     logger.verbose(`Handle attach request: ${JSON.stringify(request.arguments, null , 2)}`);
-                    return this.remoteExtension.getPackagerPort();
+                    return this.remoteExtension.getPackagerPort(request.arguments.program);
                 })
                 .then((packagerPort: number) => {
                     this.attachRequest({

--- a/src/extension/debugConfigurationProvider.ts
+++ b/src/extension/debugConfigurationProvider.ts
@@ -11,37 +11,29 @@ export class ReactNativeDebugConfigProvider implements vscode.DebugConfiguration
     private debugConfigurations = {
         "Debug Android": {
             "name": "Debug Android",
-            "program": "${workspaceRoot}/.vscode/launchReactNative.js",
             "type": "reactnative",
             "request": "launch",
             "platform": "android",
-            "sourceMaps": true,
             "outDir": "${workspaceRoot}/.vscode/.react",
         },
         "Debug iOS": {
             "name": "Debug iOS",
-            "program": "${workspaceRoot}/.vscode/launchReactNative.js",
             "type": "reactnative",
             "request": "launch",
             "platform": "ios",
-            "sourceMaps": true,
             "outDir": "${workspaceRoot}/.vscode/.react",
         },
         "Attach to packager": {
             "name": "Attach to packager",
-            "program": "${workspaceRoot}/.vscode/launchReactNative.js",
             "type": "reactnative",
             "request": "attach",
-            "sourceMaps": true,
             "outDir": "${workspaceRoot}/.vscode/.react",
         },
         "Debug in Exponent": {
             "name": "Debug in Exponent",
-            "program": "${workspaceRoot}/.vscode/launchReactNative.js",
             "type": "reactnative",
             "request": "launch",
             "platform": "exponent",
-            "sourceMaps": true,
             "outDir": "${workspaceRoot}/.vscode/.react",
         },
     };

--- a/src/extension/debugConfigurationProvider.ts
+++ b/src/extension/debugConfigurationProvider.ts
@@ -11,30 +11,30 @@ export class ReactNativeDebugConfigProvider implements vscode.DebugConfiguration
     private debugConfigurations = {
         "Debug Android": {
             "name": "Debug Android",
+            "program": "${workspaceRoot}/.vscode/launchReactNative.js",
             "type": "reactnative",
             "request": "launch",
             "platform": "android",
-            "outDir": "${workspaceRoot}/.vscode/.react",
         },
         "Debug iOS": {
             "name": "Debug iOS",
+            "program": "${workspaceRoot}/.vscode/launchReactNative.js",
             "type": "reactnative",
             "request": "launch",
             "platform": "ios",
-            "outDir": "${workspaceRoot}/.vscode/.react",
         },
         "Attach to packager": {
             "name": "Attach to packager",
+            "program": "${workspaceRoot}/.vscode/launchReactNative.js",
             "type": "reactnative",
             "request": "attach",
-            "outDir": "${workspaceRoot}/.vscode/.react",
         },
         "Debug in Exponent": {
             "name": "Debug in Exponent",
+            "program": "${workspaceRoot}/.vscode/launchReactNative.js",
             "type": "reactnative",
             "request": "launch",
             "platform": "exponent",
-            "outDir": "${workspaceRoot}/.vscode/.react",
         },
     };
 

--- a/src/extension/rn-extension.ts
+++ b/src/extension/rn-extension.ts
@@ -67,11 +67,8 @@ export function activate(context: vscode.ExtensionContext): Q.Promise<void> {
         context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((event) => onChangeConfiguration(context)));
 
         debugConfigProvider = vscode.debug.registerDebugConfigurationProvider("reactnative", configProvider);
-
         let activateExtensionEvent = TelemetryHelper.createTelemetryEvent("activate");
         Telemetry.send(activateExtensionEvent);
-
-
         let promises: any = [];
         if (workspaceFolders) {
             outputChannelLogger.debug(`Projects found: ${workspaceFolders.length}`);

--- a/test/smoke/resources/launch.json
+++ b/test/smoke/resources/launch.json
@@ -7,8 +7,6 @@
             "type": "reactnative",
             "request": "launch",
             "platform": "android",
-            "sourceMaps": true,
-            "outDir": "${workspaceRoot}/.vscode/.react"
         },
         {
             "name": "Debug iOS",
@@ -16,16 +14,12 @@
             "type": "reactnative",
             "request": "launch",
             "platform": "ios",
-            "sourceMaps": true,
-            "outDir": "${workspaceRoot}/.vscode/.react"
         },
         {
             "name": "Attach to packager",
             "program": "${workspaceRoot}/.vscode/launchReactNative.js",
             "type": "reactnative",
             "request": "attach",
-            "sourceMaps": true,
-            "outDir": "${workspaceRoot}/.vscode/.react"
         },
         {
             "name": "Debug in Exponent",
@@ -33,8 +27,6 @@
             "type": "reactnative",
             "request": "launch",
             "platform": "exponent",
-            "sourceMaps": true,
-            "outDir": "${workspaceRoot}/.vscode/.react"
         }
     ]
 }

--- a/test/smoke/resources/launch.json
+++ b/test/smoke/resources/launch.json
@@ -6,27 +6,27 @@
             "program": "${workspaceRoot}/.vscode/launchReactNative.js",
             "type": "reactnative",
             "request": "launch",
-            "platform": "android",
+            "platform": "android"
         },
         {
             "name": "Debug iOS",
             "program": "${workspaceRoot}/.vscode/launchReactNative.js",
             "type": "reactnative",
             "request": "launch",
-            "platform": "ios",
+            "platform": "ios"
         },
         {
             "name": "Attach to packager",
             "program": "${workspaceRoot}/.vscode/launchReactNative.js",
             "type": "reactnative",
-            "request": "attach",
+            "request": "attach"
         },
         {
             "name": "Debug in Exponent",
             "program": "${workspaceRoot}/.vscode/launchReactNative.js",
             "type": "reactnative",
             "request": "launch",
-            "platform": "exponent",
+            "platform": "exponent"
         }
     ]
 }


### PR DESCRIPTION
This PR implements the second part of #830.
Two properties were removed from initial debug scenarios:
* `sourceMaps` debug scenario property is now always set to true if not defined explicitly.
* `outDir` property was completely removed as not used in the code.

[AB#683](https://dev.azure.com/vscode-webdiag-extensions/5c2c3798-7e49-49f6-b45f-77d9c69636c6/_workitems/edit/683)