### PR TITLE
[Smoke tests] Add process.env.NIGHTLY parameter processing for nightly builds

### DIFF
--- a/test/smoke/src/helpers/configHelper.ts
+++ b/test/smoke/src/helpers/configHelper.ts
@@ -81,7 +81,7 @@ export class TestConfigurator {
             variables.CODE_VERSION = "*";
         }
         // Hack for Azure DevOps, because it doesn't implicitly support optional parameters for task group
-        if (variables.EXPO_XDL_VERSION === "skip" || process.env.NIGHTLY) {
+        if (variables.EXPO_XDL_VERSION === "skip") {
             delete variables.EXPO_XDL_VERSION;
         }
         if (variables.RN_VERSION === "skip" || process.env.NIGHTLY) {

--- a/test/smoke/src/helpers/configHelper.ts
+++ b/test/smoke/src/helpers/configHelper.ts
@@ -76,17 +76,21 @@ export class TestConfigurator {
             variables = process.env;
         }
 
+        if (process.env.NIGHTLY) {
+            console.log("*** This is nightly build, only the latest software versions will be used");
+            variables.CODE_VERSION = "*";
+        }
         // Hack for Azure DevOps, because it doesn't implicitly support optional parameters for task group
-        if (variables.EXPO_XDL_VERSION === "skip") {
+        if (variables.EXPO_XDL_VERSION === "skip" || process.env.NIGHTLY) {
             delete variables.EXPO_XDL_VERSION;
         }
-        if (variables.RN_VERSION === "skip") {
+        if (variables.RN_VERSION === "skip" || process.env.NIGHTLY) {
             delete variables.RN_VERSION;
         }
-        if (variables.PURE_RN_VERSION === "skip") {
+        if (variables.PURE_RN_VERSION === "skip" || process.env.NIGHTLY) {
             delete variables.PURE_RN_VERSION;
         }
-        if (variables.PURE_EXPO_VERSION === "skip") {
+        if (variables.PURE_EXPO_VERSION === "skip" || process.env.NIGHTLY) {
             delete variables.PURE_EXPO_VERSION;
         }
 

--- a/test/smoke/src/helpers/vsCodeHelper.ts
+++ b/test/smoke/src/helpers/vsCodeHelper.ts
@@ -20,12 +20,14 @@ import * as cp from "child_process";
 import { spawnSync } from "../helpers/utilities";
 
 export class VSCodeHelper {
-    private static version = process.env.CODE_VERSION || "*";
-    private static isInsiders = VSCodeHelper.version === "insiders";
+    private static version;
+    private static isInsiders;
     private static downloadPlatform = (process.platform === "darwin") ? "darwin" : process.platform === "win32" ? "win32-x64-archive" : "linux-x64";
     private static artifactsFolderName = "drop-win";
 
     public static async downloadVSCodeExecutable(targetFolder: string): Promise<any> {
+        VSCodeHelper.version = process.env.CODE_VERSION || "*";
+        VSCodeHelper.isInsiders = VSCodeHelper.version === "insiders";
         const testRunFolder = path.join(targetFolder, ".vscode-test", VSCodeHelper.isInsiders ? "insiders" : "stable");
 
         return new Promise ((resolve) => {


### PR DESCRIPTION
[AB#739](https://dev.azure.com/vscode-webdiag-extensions/5c2c3798-7e49-49f6-b45f-77d9c69636c6/_workitems/edit/739)