### PR TITLE
Fix displaying of VM_unknown calls in Call Stack for Hermes debugger

### DIFF
--- a/src/debugger/direct/directDebugAdapter.ts
+++ b/src/debugger/direct/directDebugAdapter.ts
@@ -169,7 +169,8 @@ export class DirectDebugAdapter extends ChromeDebugAdapter {
     }
 
     protected async onPaused(notification: Crdp.Debugger.PausedEvent, expectingStopReason = this._expectingStopReason): Promise<IOnPausedResult> {
-        // excluding Hermes native function calls from call stack, since VS Code can't process them properly (https://github.com/facebook/hermes/issues/168)
+        // Excluding Hermes native function calls from call stack, since VS Code can't process them properly 
+        // More info: https://github.com/facebook/hermes/issues/168
         notification.callFrames = notification.callFrames.filter(callFrame =>
             callFrame.functionName !== DirectDebugAdapter.HERMES_NATIVE_FUNCTION_NAME &&
             callFrame.location.scriptId !== DirectDebugAdapter.HERMES_NATIVE_FUNCTION_SCRIPT_ID

--- a/src/debugger/direct/directDebugAdapter.ts
+++ b/src/debugger/direct/directDebugAdapter.ts
@@ -30,7 +30,7 @@ export interface IDirectLaunchRequestArgs extends DebugProtocol.LaunchRequestArg
 export class DirectDebugAdapter extends ChromeDebugAdapter {
 
     /**
-     * @description The Hermes native functions calls mark in call stack (https://github.com/facebook/hermes/issues/168)
+     * @description The Hermes native functions calls mark in call stack
      * @type {string}
      */
     private static HERMES_NATIVE_FUNCTION_NAME: string = "(native)";

--- a/src/debugger/direct/directDebugAdapter.ts
+++ b/src/debugger/direct/directDebugAdapter.ts
@@ -29,8 +29,15 @@ export interface IDirectLaunchRequestArgs extends DebugProtocol.LaunchRequestArg
 
 export class DirectDebugAdapter extends ChromeDebugAdapter {
 
-    private static HERMES_NATIVE_FUNCTION_NAME: string = "(native)"; // the name of Hermes native functions in call stack (https://github.com/facebook/hermes/issues/168)
-    private static HERMES_NATIVE_FUNCTION_SCRIPT_ID: string = "4294967295"; // equals to 0xfffffff -  the scriptId returned by Hermes debugger, that means "invalid script ID"
+    /**
+     * @type {string} - the Hermes native functions calls mark in call stack (https://github.com/facebook/hermes/issues/168)
+     */
+    private static HERMES_NATIVE_FUNCTION_NAME: string = "(native)";
+    
+    /**
+     * @type {string} - equals to 0xfffffff - the scriptId returned by Hermes debugger, that means "invalid script ID"
+     */
+    private static HERMES_NATIVE_FUNCTION_SCRIPT_ID: string = "4294967295";
 
     private outputLogger: (message: string, error?: boolean | string) => void;
     private projectRootPath: string;

--- a/src/debugger/direct/directDebugAdapter.ts
+++ b/src/debugger/direct/directDebugAdapter.ts
@@ -30,12 +30,14 @@ export interface IDirectLaunchRequestArgs extends DebugProtocol.LaunchRequestArg
 export class DirectDebugAdapter extends ChromeDebugAdapter {
 
     /**
-     * @type {string} - the Hermes native functions calls mark in call stack (https://github.com/facebook/hermes/issues/168)
+     * @description The Hermes native functions calls mark in call stack (https://github.com/facebook/hermes/issues/168)
+     * @type {string}
      */
     private static HERMES_NATIVE_FUNCTION_NAME: string = "(native)";
-    
+
     /**
-     * @type {string} - equals to 0xfffffff - the scriptId returned by Hermes debugger, that means "invalid script ID"
+     * @description Equals to 0xfffffff - the scriptId returned by Hermes debugger, that means "invalid script ID"
+     * @type {string}
      */
     private static HERMES_NATIVE_FUNCTION_SCRIPT_ID: string = "4294967295";
 

--- a/src/debugger/direct/directDebugAdapter.ts
+++ b/src/debugger/direct/directDebugAdapter.ts
@@ -169,7 +169,7 @@ export class DirectDebugAdapter extends ChromeDebugAdapter {
     }
 
     protected async onPaused(notification: Crdp.Debugger.PausedEvent, expectingStopReason = this._expectingStopReason): Promise<IOnPausedResult> {
-        // Excluding Hermes native function calls from call stack, since VS Code can't process them properly 
+        // Excluding Hermes native function calls from call stack, since VS Code can't process them properly
         // More info: https://github.com/facebook/hermes/issues/168
         notification.callFrames = notification.callFrames.filter(callFrame =>
             callFrame.functionName !== DirectDebugAdapter.HERMES_NATIVE_FUNCTION_NAME &&

--- a/src/debugger/direct/directDebugAdapter.ts
+++ b/src/debugger/direct/directDebugAdapter.ts
@@ -12,7 +12,7 @@ import { Telemetry } from "../../common/telemetry";
 import { OutputEvent, Logger } from "vscode-debugadapter";
 import { TelemetryHelper } from "../../common/telemetryHelper";
 import { RemoteTelemetryReporter } from "../../common/telemetryReporters";
-import { ChromeDebugAdapter, ChromeDebugSession, IChromeDebugSessionOpts, IAttachRequestArgs, logger } from "vscode-chrome-debug-core";
+import { ChromeDebugAdapter, ChromeDebugSession, IChromeDebugSessionOpts, IAttachRequestArgs, logger, IOnPausedResult, Crdp } from "vscode-chrome-debug-core";
 import { InternalErrorCode } from "../../common/error/internalErrorCode";
 import { RemoteExtension } from "../../common/remoteExtension";
 import { DebugProtocol } from "vscode-debugprotocol";
@@ -28,6 +28,9 @@ export interface IDirectAttachRequestArgs extends IAttachRequestArgs, ILaunchArg
 export interface IDirectLaunchRequestArgs extends DebugProtocol.LaunchRequestArguments, IDirectAttachRequestArgs { }
 
 export class DirectDebugAdapter extends ChromeDebugAdapter {
+
+    private static HERMES_NATIVE_FUNCTION_NAME: string = "(native)"; // the name of Hermes native functions in call stack (https://github.com/facebook/hermes/issues/168)
+    private static HERMES_NATIVE_FUNCTION_SCRIPT_ID: string = "4294967295"; // equals to 0xfffffff -  the scriptId returned by Hermes debugger, that means "invalid script ID"
 
     private outputLogger: (message: string, error?: boolean | string) => void;
     private projectRootPath: string;
@@ -154,6 +157,15 @@ export class DirectDebugAdapter extends ChromeDebugAdapter {
     public disconnect(args: DebugProtocol.DisconnectArguments): void {
         this.cleanUp();
         super.disconnect(args);
+    }
+
+    protected async onPaused(notification: Crdp.Debugger.PausedEvent, expectingStopReason = this._expectingStopReason): Promise<IOnPausedResult> {
+        // excluding Hermes native function calls from call stack, since VS Code can't process them properly (https://github.com/facebook/hermes/issues/168)
+        notification.callFrames = notification.callFrames.filter(callFrame =>
+            callFrame.functionName !== DirectDebugAdapter.HERMES_NATIVE_FUNCTION_NAME &&
+            callFrame.location.scriptId !== DirectDebugAdapter.HERMES_NATIVE_FUNCTION_SCRIPT_ID
+            );
+        return super.onPaused(notification, expectingStopReason);
     }
 
     private initializeSettings(args: any): Q.Promise<any> {


### PR DESCRIPTION
Fixes issue №3 from https://github.com/microsoft/vscode-react-native/issues/1099 
https://github.com/facebook/hermes/issues/168
