### PR TITLE
Add Windows configuration to the presets

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,17 @@
 						}
 					},
 					{
+						"label": "React Native: Debug Windows",
+						"description": "%reactNative.snippets.debugWindows.description%",
+						"body": {
+							"name": "Debug Windows",
+							"cwd": "^\"\\${workspaceFolder}\"",
+							"type": "reactnative",
+							"request": "launch",
+							"platform": "windows"
+						}
+					},
+					{
 						"label": "React Native: Attach to packager",
 						"description": "%reactNative.snippets.attachPackager.description%",
 						"body": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -16,6 +16,7 @@
     "reactNative.snippets.debugAndroid.description":"A new configuration for launching react-native app on android",
     "reactNative.snippets.debugAndroidHermes.description":"A new configuration for launching React Native Hermes app on Android",
     "reactNative.snippets.debugiOS.description":"A new configuration for launching react-native app on iOS",
+    "reactNative.snippets.debugWindows.description":"A new configuration for launching react-native app on Windows",
     "reactNative.snippets.attachPackager.description":"A new configuration for attaching to packager",
     "reactNative.snippets.attachPackagerHermes.description":"A new configuration for attaching to packager of Android Hermes app",
     "reactNative.snippets.debugExpo.description":"A new configuration for launching Expo app",

--- a/src/extension/debugConfigurationProvider.ts
+++ b/src/extension/debugConfigurationProvider.ts
@@ -23,6 +23,13 @@ export class ReactNativeDebugConfigProvider implements vscode.DebugConfiguration
             "request": "launch",
             "platform": "ios",
         },
+        "Debug Windows": {
+            "name": "Debug Windows",
+            "cwd": "${workspaceFolder}",
+            "type": "reactnative",
+            "request": "launch",
+            "platform": "windows",
+        },
         "Attach to packager": {
             "name": "Attach to packager",
             "cwd": "${workspaceFolder}",
@@ -59,6 +66,10 @@ export class ReactNativeDebugConfigProvider implements vscode.DebugConfiguration
         {
             label: "Debug iOS",
             description: localize("DebugiOSConfigDesc", "Run and debug iOS application"),
+        },
+        {
+            label: "Debug Windows",
+            description: localize("DebugWindowsConfigDesc", "Run and debug Windows application"),
         },
         {
             label: "Attach to packager",


### PR DESCRIPTION
Implements [https://github.com/microsoft/react-native-windows/issues/3593](https://github.com/microsoft/react-native-windows/issues/3593)
When creating a launch.json, the new configuration is presented like this:
![RNW_create_launch](https://user-images.githubusercontent.com/12337821/71634993-5c9c5880-2bd5-11ea-9d8b-c3e1730e7476.png)
When editing the launch.json, the new configuration is presented like this (after pressing the "Add Configuration..." button):
![RNW_edit_launch](https://user-images.githubusercontent.com/12337821/71634995-64f49380-2bd5-11ea-92a8-37ca6cd55019.png)

First time contributing, I apologize if everything is wrong!