### PR TITLE
Show clearer message when debugging windows without react native windows installed

### DIFF
--- a/src/common/error/errorStrings.ts
+++ b/src/common/error/errorStrings.ts
@@ -42,6 +42,7 @@ export const ERROR_STRINGS = {
     [InternalErrorCode.CouldNotFindLocationOfNodeDebugger]: localize("CouldNotFindLocationOfNodeDebugger", "Couldn't find the location of the node-debugger extension"),
     [InternalErrorCode.CouldNotFindWorkspace]: localize("CouldNotFindWorkspace", "Couldn't find any workspace or React Native project folder"),
     [InternalErrorCode.ReactNativePackageIsNotInstalled]: localize("ReactNativePackageIsNotInstalled", "Couldn't find react-native package in node_modules. Please, run \"npm install\" inside your project to install it."),
+    [InternalErrorCode.ReactNativeWindowsIsNotInstalled]: localize("ReactNativeWindowsIsNotInstalled", "It appears you don't have react-native-windows installed. Go to https://github.com/microsoft/react-native-windows#getting-started for more info."),
     [InternalErrorCode.PackagerRunningInDifferentPort]: localize("PackagerRunningInDifferentPort", "A packager cannot be started on port {0} because a packager process is already running on port {1}"),
     [InternalErrorCode.ErrorWhileProcessingMessageInIPMSServer]: localize("ErrorWhileProcessingMessageInIPMSServer", "An error ocurred while handling message: {0}"),
     [InternalErrorCode.ErrorNoPipeFound]: localize("ErrorNoPipeFound", "Unable to set up communication with VSCode react-native extension. Is this a react-native project, and have you made sure that the react-native npm package is installed at the root?"),

--- a/src/common/error/errorStrings.ts
+++ b/src/common/error/errorStrings.ts
@@ -42,7 +42,7 @@ export const ERROR_STRINGS = {
     [InternalErrorCode.CouldNotFindLocationOfNodeDebugger]: localize("CouldNotFindLocationOfNodeDebugger", "Couldn't find the location of the node-debugger extension"),
     [InternalErrorCode.CouldNotFindWorkspace]: localize("CouldNotFindWorkspace", "Couldn't find any workspace or React Native project folder"),
     [InternalErrorCode.ReactNativePackageIsNotInstalled]: localize("ReactNativePackageIsNotInstalled", "Couldn't find react-native package in node_modules. Please, run \"npm install\" inside your project to install it."),
-    [InternalErrorCode.ReactNativeWindowsIsNotInstalled]: localize("ReactNativeWindowsIsNotInstalled", "It appears you don't have react-native-windows installed. Go to https://github.com/microsoft/react-native-windows#getting-started for more info."),
+    [InternalErrorCode.ReactNativeWindowsIsNotInstalled]: localize("ReactNativeWindowsIsNotInstalled", "It appears you don't have 'react-native-windows' package installed. Please proceed to https://github.com/microsoft/react-native-windows#getting-started for more info."),
     [InternalErrorCode.PackagerRunningInDifferentPort]: localize("PackagerRunningInDifferentPort", "A packager cannot be started on port {0} because a packager process is already running on port {1}"),
     [InternalErrorCode.ErrorWhileProcessingMessageInIPMSServer]: localize("ErrorWhileProcessingMessageInIPMSServer", "An error ocurred while handling message: {0}"),
     [InternalErrorCode.ErrorNoPipeFound]: localize("ErrorNoPipeFound", "Unable to set up communication with VSCode react-native extension. Is this a react-native project, and have you made sure that the react-native npm package is installed at the root?"),

--- a/src/common/error/internalErrorCode.ts
+++ b/src/common/error/internalErrorCode.ts
@@ -44,6 +44,7 @@ export enum InternalErrorCode {
         NotInReactNativeFolderError = 604,
         CouldNotFindProjectVersion = 605,
         ReactNativePackageIsNotInstalled = 606,
+        ReactNativeWindowsIsNotInstalled = 607,
 
         // Miscellaneous errors
         TelemetryInitializationFailed = 701,

--- a/src/extension/extensionServer.ts
+++ b/src/extension/extensionServer.ts
@@ -237,7 +237,10 @@ export class ExtensionServer implements vscode.Disposable {
                 .then(versions => {
                     mobilePlatformOptions.reactNativeVersions = versions;
                     extProps = TelemetryHelper.addPropertyToTelemetryProperties(versions.reactNativeVersion, "reactNativeVersion", extProps);
-                    if (!ProjectVersionHelper.isVersionError(versions.reactNativeWindowsVersion)) {
+                    if (request.arguments.platform === "windows") {
+                        if (ProjectVersionHelper.isVersionError(versions.reactNativeWindowsVersion)) {
+                            throw ErrorHelper.getInternalError(InternalErrorCode.ReactNativeWindowsIsNotInstalled);
+                        }
                         extProps = TelemetryHelper.addPropertyToTelemetryProperties(versions.reactNativeWindowsVersion, "reactNativeWindowsVersion", extProps);
                     }
                     TelemetryHelper.generate("launch", extProps, (generator) => {

--- a/src/extension/windows/windowsPlatform.ts
+++ b/src/extension/windows/windowsPlatform.ts
@@ -10,6 +10,9 @@ import {OutputVerifier, PatternToFailure} from "../../common/outputVerifier";
 import {TelemetryHelper} from "../../common/telemetryHelper";
 import {CommandExecutor} from "../../common/commandExecutor";
 import { InternalErrorCode } from "../../common/error/internalErrorCode";
+import { ProjectVersionHelper } from "../../common/projectVersionHelper";
+import * as nls from "vscode-nls";
+const localize = nls.loadMessageBundle();
 
 /**
  * Windows specific platform implementation for debugging RN applications.
@@ -52,6 +55,10 @@ export class WindowsPlatform extends GeneralMobilePlatform {
 
             if (!semver.valid(this.runOptions.reactNativeVersions.reactNativeVersion) /*Custom RN implementations should support this flag*/ || semver.gte(this.runOptions.reactNativeVersions.reactNativeVersion, WindowsPlatform.NO_PACKAGER_VERSION)) {
                 this.runArguments.push("--no-packager");
+            }
+
+            if (ProjectVersionHelper.isVersionError(this.runOptions.reactNativeVersions.reactNativeWindowsVersion)) {
+                this.logger.warning(localize("ReactNativeWindowsNotInstalled", "It appears you don't have react-native-windows installed. Go to https://github.com/microsoft/react-native-windows#getting-started for more info."));
             }
 
             const runWindowsSpawn = new CommandExecutor(this.projectPath, this.logger).spawnReactCommand(`run-${this.platformName}`, this.runArguments, {env});

--- a/src/extension/windows/windowsPlatform.ts
+++ b/src/extension/windows/windowsPlatform.ts
@@ -10,9 +10,6 @@ import {OutputVerifier, PatternToFailure} from "../../common/outputVerifier";
 import {TelemetryHelper} from "../../common/telemetryHelper";
 import {CommandExecutor} from "../../common/commandExecutor";
 import { InternalErrorCode } from "../../common/error/internalErrorCode";
-import { ProjectVersionHelper } from "../../common/projectVersionHelper";
-import * as nls from "vscode-nls";
-const localize = nls.loadMessageBundle();
 
 /**
  * Windows specific platform implementation for debugging RN applications.
@@ -55,10 +52,6 @@ export class WindowsPlatform extends GeneralMobilePlatform {
 
             if (!semver.valid(this.runOptions.reactNativeVersions.reactNativeVersion) /*Custom RN implementations should support this flag*/ || semver.gte(this.runOptions.reactNativeVersions.reactNativeVersion, WindowsPlatform.NO_PACKAGER_VERSION)) {
                 this.runArguments.push("--no-packager");
-            }
-
-            if (ProjectVersionHelper.isVersionError(this.runOptions.reactNativeVersions.reactNativeWindowsVersion)) {
-                this.logger.warning(localize("ReactNativeWindowsNotInstalled", "It appears you don't have react-native-windows installed. Go to https://github.com/microsoft/react-native-windows#getting-started for more info."));
             }
 
             const runWindowsSpawn = new CommandExecutor(this.projectPath, this.logger).spawnReactCommand(`run-${this.platformName}`, this.runArguments, {env});


### PR DESCRIPTION
Based on follow up comments in [https://github.com/microsoft/react-native-windows/issues/3593](https://github.com/microsoft/react-native-windows/issues/3593).
Prints the following warning message: `It appears you don't have react-native-windows installed. Go to https://github.com/microsoft/react-native-windows#getting-started for more info.` when the user tries to debug windows and it seems that react native windows is not installed.
Previously, only the following was printed out: `error Unrecognized command "run-windows".`