### PR TITLE
Add telemetry for Expo host types

### DIFF
--- a/src/extension/exponent/exponentPlatform.ts
+++ b/src/extension/exponent/exponentPlatform.ts
@@ -37,6 +37,7 @@ export class ExponentPlatform extends GeneralMobilePlatform {
         };
 
         extProps = TelemetryHelper.addPropertyToTelemetryProperties(this.runOptions.reactNativeVersions.reactNativeVersion, "reactNativeVersion", extProps);
+        extProps = TelemetryHelper.addPropertyToTelemetryProperties(this.runOptions.expoHostType, "expoHostType", extProps);
 
         return TelemetryHelper.generate("ExponentPlatform.runApp", extProps, () => {
             return this.loginToExponentOrSkip(this.runOptions.expoHostType)


### PR DESCRIPTION
This PR adds `expoHostType` property to `ExponentPlatform.runApp` telemetry event.
Example: 
![image](https://user-images.githubusercontent.com/32372875/75032572-ebcd3a80-54b9-11ea-984d-e57d59cc5e52.png)
