### PR TITLE
Refactoring of caching of projects instances

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -226,12 +226,12 @@
 			}
 		},
 		"ajv": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-			"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+			"version": "6.11.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
+			"integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
 			"dev": true,
 			"requires": {
-				"fast-deep-equal": "^2.0.1",
+				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
@@ -546,9 +546,9 @@
 			"dev": true
 		},
 		"aws4": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+			"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
 			"dev": true
 		},
 		"azure-devops-node-api": {
@@ -2058,15 +2058,15 @@
 			}
 		},
 		"fast-deep-equal": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
 			"dev": true
 		},
 		"fast-json-stable-stringify": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
 			"dev": true
 		},
 		"fast-levenshtein": {
@@ -3900,9 +3900,9 @@
 			}
 		},
 		"https-proxy-agent": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.3.tgz",
-			"integrity": "sha512-Ytgnz23gm2DVftnzqRRz2dOXZbGd2uiajSw/95bPp6v53zPRspQjLm/AfBgqbJ2qfeRXWIOMVLpp86+/5yX39Q==",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+			"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
 			"dev": true,
 			"requires": {
 				"agent-base": "^4.3.0",
@@ -4739,18 +4739,18 @@
 			"dev": true
 		},
 		"mime-db": {
-			"version": "1.40.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-			"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+			"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
 			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.24",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-			"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+			"version": "2.1.26",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+			"integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.40.0"
+				"mime-db": "1.43.0"
 			}
 		},
 		"mimic-fn": {
@@ -5649,9 +5649,9 @@
 			"dev": true
 		},
 		"psl": {
-			"version": "1.1.33",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.33.tgz",
-			"integrity": "sha512-LTDP2uSrsc7XCb5lO7A8BI1qYxRe/8EqlRvMeEl6rsnYAqDOl8xHR+8lSAIVfrNaSAlTPTNOCgNjWcoUL3AZsw==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
+			"integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==",
 			"dev": true
 		},
 		"pump": {
@@ -5961,9 +5961,9 @@
 			}
 		},
 		"request": {
-			"version": "2.88.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+			"version": "2.88.2",
+			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
 			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
@@ -5973,7 +5973,7 @@
 				"extend": "~3.0.2",
 				"forever-agent": "~0.6.1",
 				"form-data": "~2.3.2",
-				"har-validator": "~5.1.0",
+				"har-validator": "~5.1.3",
 				"http-signature": "~1.2.0",
 				"is-typedarray": "~1.0.0",
 				"isstream": "~0.1.2",
@@ -5983,7 +5983,7 @@
 				"performance-now": "^2.1.0",
 				"qs": "~6.5.2",
 				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.4.3",
+				"tough-cookie": "~2.5.0",
 				"tunnel-agent": "^0.6.0",
 				"uuid": "^3.3.2"
 			}
@@ -6693,21 +6693,13 @@
 			}
 		},
 		"tough-cookie": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
 			"dev": true,
 			"requires": {
-				"psl": "^1.1.24",
-				"punycode": "^1.4.1"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-					"dev": true
-				}
+				"psl": "^1.1.28",
+				"punycode": "^2.1.1"
 			}
 		},
 		"trim-right": {
@@ -7071,9 +7063,9 @@
 			"dev": true
 		},
 		"uuid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
 			"dev": true
 		},
 		"v8flags": {
@@ -7371,9 +7363,9 @@
 			}
 		},
 		"vscode": {
-			"version": "1.1.35",
-			"resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.35.tgz",
-			"integrity": "sha512-xPnxzQU40LOS2yPyzWW+WKpTV6qA3z16TcgpZ9O38UWLA157Zz4GxUx5H7Gd07pxzw0GqvusbF4D+5GBgNxvEQ==",
+			"version": "1.1.36",
+			"resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.36.tgz",
+			"integrity": "sha512-cGFh9jmGLcTapCpPCKvn8aG/j9zVQ+0x5hzYJq5h5YyUXVGa1iamOaB2M2PZXoumQPES4qeAP1FwkI0b6tL4bQ==",
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.2",
@@ -7386,9 +7378,9 @@
 			},
 			"dependencies": {
 				"semver": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 					"dev": true
 				},
 				"source-map": {
@@ -7398,9 +7390,9 @@
 					"dev": true
 				},
 				"source-map-support": {
-					"version": "0.5.12",
-					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
-					"integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
+					"version": "0.5.16",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+					"integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
 					"dev": true,
 					"requires": {
 						"buffer-from": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"url": "https://github.com/Microsoft/vscode-react-native"
 	},
 	"engines": {
-		"vscode": "^1.26.0"
+		"vscode": "^1.35.0"
 	},
 	"categories": [
 		"Debuggers",
@@ -112,7 +112,6 @@
 			{
 				"type": "reactnative",
 				"label": "React Native",
-				"program": "./src/debugger/reactNativeDebugEntryPoint.js",
 				"runtime": "node",
 				"enableBreakpointsFor": {
 					"languageIds": [
@@ -381,7 +380,6 @@
 			{
 				"type": "reactnativedirect",
 				"label": "React Native Direct - Experimental",
-				"program": "./src/debugger/direct/reactNativeDirectDebugEntryPoint.js",
 				"runtime": "node",
 				"enableBreakpointsFor": {
 					"languageIds": [
@@ -742,7 +740,7 @@
 		"tslint": "^5.17.0",
 		"typescript": "^2.8.3",
 		"vsce": "^1.65.0",
-		"vscode": "^1.1.35",
+		"vscode": "^1.1.36",
 		"vscode-nls-dev": "^3.3.1"
 	},
 	"extensionDependencies": [

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+export function isNullOrUndefined(value: any): boolean {
+    return typeof value === "undefined" || value === null;
+}

--- a/src/debugger/rnDebugSession.ts
+++ b/src/debugger/rnDebugSession.ts
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+import * as vscode from "vscode";
+import * as Q from "q";
+import * as path from "path";
+import * as fs from "fs";
+import stripJsonComments = require("strip-json-comments");
+import { LoggingDebugSession, Logger, logger } from "vscode-debugadapter";
+import { DebugProtocol } from "vscode-debugprotocol";
+import { getLoggingDirectory } from "../extension/log/LogHelper";
+import { ReactNativeProjectHelper } from "../common/reactNativeProjectHelper";
+import { ErrorHelper } from "../common/error/errorHelper";
+import { InternalErrorCode } from "../common/error/internalErrorCode";
+import { ILaunchArgs } from "../extension/launchArgs";
+import { ProjectVersionHelper } from "../common/projectVersionHelper";
+import { TelemetryHelper } from "../common/telemetryHelper";
+
+export interface IAttachRequestArgs extends DebugProtocol.AttachRequestArguments, ILaunchArgs {
+    cwd: string; /* Automatically set by VS Code to the currently opened folder */
+    port: number;
+    url?: string;
+    address?: string;
+}
+
+export interface ILaunchRequestArgs extends DebugProtocol.LaunchRequestArguments, IAttachRequestArgs { }
+
+export class RNDebugSession extends LoggingDebugSession {
+
+    private projectRootPath: string;
+    // private remoteExtension: RemoteExtension;
+
+    constructor(private session: vscode.DebugSession) {
+        super();
+    }
+
+    protected initializeRequest(response: DebugProtocol.InitializeResponse, args: DebugProtocol.InitializeRequestArguments): void {
+        super.initializeRequest(response, args);
+    }
+
+    protected launchRequest(response: DebugProtocol.LaunchResponse, args: ILaunchRequestArgs, request?: DebugProtocol.Request): Promise<void> {
+
+        return Promise.resolve();
+    }
+
+    protected attachRequest(response: DebugProtocol.AttachResponse, args: IAttachRequestArgs, request?: DebugProtocol.Request): void {
+
+    }
+
+    private initializeSettings(args: any): Q.Promise<any> {
+        let chromeDebugCoreLogs = getLoggingDirectory();
+        if (chromeDebugCoreLogs) {
+            chromeDebugCoreLogs = path.join(chromeDebugCoreLogs, "ChromeDebugCoreLogs.txt");
+        }
+        let logLevel: string = args.trace;
+        if (logLevel) {
+            logLevel = logLevel.replace(logLevel[0], logLevel[0].toUpperCase());
+            logger.setup(Logger.LogLevel[logLevel], chromeDebugCoreLogs || false);
+        } else {
+            logger.setup(Logger.LogLevel.Log, chromeDebugCoreLogs || false);
+        }
+
+        if (!args.sourceMaps) {
+            args.sourceMaps = true;
+        }
+
+        const projectRootPath = getProjectRoot(args);
+        return ReactNativeProjectHelper.isReactNativeProject(projectRootPath)
+            .then((result) => {
+                if (!result) {
+                    throw ErrorHelper.getInternalError(InternalErrorCode.NotInReactNativeFolderError);
+                }
+                this.projectRootPath = projectRootPath;
+
+                return void 0;
+            });
+    }
+}
+
+/**
+ * Parses settings.json file for workspace root property
+ */
+function getProjectRoot(args: any): string {
+    const vsCodeRoot = args.cwd ? path.resolve(args.cwd) : path.resolve(args.program, "../..");
+    const settingsPath = path.resolve(vsCodeRoot, ".vscode/settings.json");
+    try {
+        let settingsContent = fs.readFileSync(settingsPath, "utf8");
+        settingsContent = stripJsonComments(settingsContent);
+        let parsedSettings = JSON.parse(settingsContent);
+        let projectRootPath = parsedSettings["react-native-tools.projectRoot"] || parsedSettings["react-native-tools"].projectRoot;
+        return path.resolve(vsCodeRoot, projectRootPath);
+    } catch (e) {
+        logger.verbose(`${settingsPath} file doesn't exist or its content is incorrect. This file will be ignored.`);
+        return args.cwd ? path.resolve(args.cwd) : path.resolve(args.program, "../..");
+    }
+}

--- a/src/debugger/rnDebugSession.ts
+++ b/src/debugger/rnDebugSession.ts
@@ -5,6 +5,7 @@ import * as vscode from "vscode";
 import * as Q from "q";
 import * as path from "path";
 import * as fs from "fs";
+import * as mkdirp from "mkdirp";
 import stripJsonComments = require("strip-json-comments");
 import { LoggingDebugSession, Logger, logger } from "vscode-debugadapter";
 import { DebugProtocol } from "vscode-debugprotocol";
@@ -15,6 +16,11 @@ import { InternalErrorCode } from "../common/error/internalErrorCode";
 import { ILaunchArgs } from "../extension/launchArgs";
 import { ProjectVersionHelper } from "../common/projectVersionHelper";
 import { TelemetryHelper } from "../common/telemetryHelper";
+import { ProjectsStorage } from "../extension/projectsStorage";
+import { AppLauncher } from "../extension/appLauncher";
+import { MultipleLifetimesAppWorker } from "./appWorker";
+import * as nls from "vscode-nls";
+const localize = nls.loadMessageBundle();
 
 export interface IAttachRequestArgs extends DebugProtocol.AttachRequestArguments, ILaunchArgs {
     cwd: string; /* Automatically set by VS Code to the currently opened folder */
@@ -27,8 +33,10 @@ export interface ILaunchRequestArgs extends DebugProtocol.LaunchRequestArguments
 
 export class RNDebugSession extends LoggingDebugSession {
 
+    private appLauncher: AppLauncher;
+    private appWorker: MultipleLifetimesAppWorker | null = null;
     private projectRootPath: string;
-    // private remoteExtension: RemoteExtension;
+    private isSettingsInitialized: boolean; // used to prevent parameters reinitialization when attach is called from launch function
 
     constructor(private session: vscode.DebugSession) {
         super();
@@ -38,42 +46,141 @@ export class RNDebugSession extends LoggingDebugSession {
         super.initializeRequest(response, args);
     }
 
-    protected launchRequest(response: DebugProtocol.LaunchResponse, args: ILaunchRequestArgs, request?: DebugProtocol.Request): Promise<void> {
+    protected launchRequest(response: DebugProtocol.LaunchResponse, launchArgs: ILaunchRequestArgs, request?: DebugProtocol.Request): Promise<void> {
+        return new Promise<void>((resolve, reject) => this.initializeSettings(launchArgs)
+            .then(() => {
+                logger.log("Launching the application");
+                logger.verbose(`Launching the application: ${JSON.stringify(launchArgs, null , 2)}`);
 
-        return Promise.resolve();
+                this.appLauncher.launch(launchArgs)
+                    .then(() => {
+                        return this.appLauncher.getPackagerPort(launchArgs.cwd);
+                    })
+                    .then((packagerPort: number) => {
+                        launchArgs.port = launchArgs.port || packagerPort;
+                        this.attachRequest(response, launchArgs).then(() => {
+                            resolve();
+                        }).catch((e) => reject(e));
+                    })
+                    .catch((err) => {
+                        logger.error("An error occurred while attaching to the debugger. " + err.message || err);
+                        reject(err);
+                    });
+            }));
     }
 
-    protected attachRequest(response: DebugProtocol.AttachResponse, args: IAttachRequestArgs, request?: DebugProtocol.Request): void {
+    protected attachRequest(response: DebugProtocol.AttachResponse, attachArgs: IAttachRequestArgs, request?: DebugProtocol.Request): Promise<void>  {
+        let extProps = {
+            platform: {
+                value: attachArgs.platform,
+                isPii: false,
+            },
+        };
 
+        return new Promise<void>((resolve, reject) => this.initializeSettings(attachArgs)
+            .then(() => {
+                logger.log("Attaching to the application");
+                logger.verbose(`Attaching to the application: ${JSON.stringify(attachArgs, null , 2)}`);
+                return ProjectVersionHelper.getReactNativeVersions(attachArgs.cwd, true)
+                    .then(versions => {
+                        extProps = TelemetryHelper.addPropertyToTelemetryProperties(versions.reactNativeVersion, "reactNativeVersion", extProps);
+                        if (!ProjectVersionHelper.isVersionError(versions.reactNativeWindowsVersion)) {
+                            extProps = TelemetryHelper.addPropertyToTelemetryProperties(versions.reactNativeWindowsVersion, "reactNativeWindowsVersion", extProps);
+                        }
+                        return TelemetryHelper.generate("attach", extProps, (generator) => {
+                            logger.log(localize("StartingDebuggerAppWorker", "Starting debugger app worker."));
+
+                            const sourcesStoragePath = path.join(this.projectRootPath, ".vscode", ".react");
+                            // Create folder if not exist to avoid problems if
+                            // RN project root is not a ${workspaceFolder}
+                            mkdirp.sync(sourcesStoragePath);
+
+                            // If launch is invoked first time, appWorker is undefined, so create it here
+                            this.appWorker = new MultipleLifetimesAppWorker(
+                                attachArgs,
+                                sourcesStoragePath,
+                                this.projectRootPath,
+                                undefined);
+
+                            this.appWorker.on("connected", (port: number) => {
+                                logger.log(localize("DebuggerWorkerLoadedRuntimeOnPort", "Debugger worker loaded runtime on port {0}", port));
+
+                                const attachArguments = {
+                                    type: "node",
+                                    request: "attach",
+                                    name: "Attach",
+                                    port: port,
+                                };
+
+                                vscode.debug.startDebugging(
+                                    this.appLauncher.getWorkspaceFolder(),
+                                    attachArguments,
+                                    this.session
+                                )
+                                .then((childDebugSessionStarted: boolean) => {
+                                    if (childDebugSessionStarted) {
+                                        resolve();
+                                    } else {
+                                        reject(new Error("Can not start child debug session"));
+                                    }
+                                },
+                                err => {
+                                    reject(err);
+                                });
+                            });
+
+                            return this.appWorker.start();
+                        })
+                        .catch((err) => {
+                            logger.error("An error occurred while attaching to the debugger. " + err.message || err);
+                            reject(err);
+                        });
+                    });
+        }));
     }
+
+    protected disconnectRequest(response: DebugProtocol.DisconnectResponse, args: DebugProtocol.DisconnectArguments, request?: DebugProtocol.Request): void {
+        // The client is about to disconnect so first we need to stop app worker
+       if (this.appWorker) {
+           this.appWorker.stop();
+       }
+
+       super.disconnectRequest(response, args, request);
+   }
 
     private initializeSettings(args: any): Q.Promise<any> {
-        let chromeDebugCoreLogs = getLoggingDirectory();
-        if (chromeDebugCoreLogs) {
-            chromeDebugCoreLogs = path.join(chromeDebugCoreLogs, "ChromeDebugCoreLogs.txt");
-        }
-        let logLevel: string = args.trace;
-        if (logLevel) {
-            logLevel = logLevel.replace(logLevel[0], logLevel[0].toUpperCase());
-            logger.setup(Logger.LogLevel[logLevel], chromeDebugCoreLogs || false);
+        if (!this.isSettingsInitialized) {
+            let chromeDebugCoreLogs = getLoggingDirectory();
+            if (chromeDebugCoreLogs) {
+                chromeDebugCoreLogs = path.join(chromeDebugCoreLogs, "ChromeDebugCoreLogs.txt");
+            }
+            let logLevel: string = args.trace;
+            if (logLevel) {
+                logLevel = logLevel.replace(logLevel[0], logLevel[0].toUpperCase());
+                logger.setup(Logger.LogLevel[logLevel], chromeDebugCoreLogs || false);
+            } else {
+                logger.setup(Logger.LogLevel.Log, chromeDebugCoreLogs || false);
+            }
+
+            if (!args.sourceMaps) {
+                args.sourceMaps = true;
+            }
+
+            const projectRootPath = getProjectRoot(args);
+            return ReactNativeProjectHelper.isReactNativeProject(projectRootPath)
+                .then((result) => {
+                    if (!result) {
+                        throw ErrorHelper.getInternalError(InternalErrorCode.NotInReactNativeFolderError);
+                    }
+                    this.projectRootPath = projectRootPath;
+                    this.appLauncher = ProjectsStorage.projectsCache[projectRootPath];
+                    this.isSettingsInitialized = true;
+
+                    return void 0;
+                });
         } else {
-            logger.setup(Logger.LogLevel.Log, chromeDebugCoreLogs || false);
+            return Q.resolve<void>(void 0);
         }
-
-        if (!args.sourceMaps) {
-            args.sourceMaps = true;
-        }
-
-        const projectRootPath = getProjectRoot(args);
-        return ReactNativeProjectHelper.isReactNativeProject(projectRootPath)
-            .then((result) => {
-                if (!result) {
-                    throw ErrorHelper.getInternalError(InternalErrorCode.NotInReactNativeFolderError);
-                }
-                this.projectRootPath = projectRootPath;
-
-                return void 0;
-            });
     }
 }
 

--- a/src/extension/appLauncher.ts
+++ b/src/extension/appLauncher.ts
@@ -104,44 +104,44 @@ export class AppLauncher {
         return SettingsHelper.getPackagerPort(projectFolder);
     }
 
-    public launch(request: any): Promise<any> {
-        let mobilePlatformOptions = this.requestSetup(request.arguments);
+    public launch(launchArgs: any): Promise<any> {
+        let mobilePlatformOptions = this.requestSetup(launchArgs);
 
         // We add the parameter if it's defined (adapter crashes otherwise)
-        if (!isNullOrUndefined(request.arguments.logCatArguments)) {
-            mobilePlatformOptions.logCatArguments = [this.parseLogCatArguments(request.arguments.logCatArguments)];
+        if (!isNullOrUndefined(launchArgs.logCatArguments)) {
+            mobilePlatformOptions.logCatArguments = [this.parseLogCatArguments(launchArgs.logCatArguments)];
         }
 
-        if (!isNullOrUndefined(request.arguments.variant)) {
-            mobilePlatformOptions.variant = request.arguments.variant;
+        if (!isNullOrUndefined(launchArgs.variant)) {
+            mobilePlatformOptions.variant = launchArgs.variant;
         }
 
-        if (!isNullOrUndefined(request.arguments.scheme)) {
-            mobilePlatformOptions.scheme = request.arguments.scheme;
+        if (!isNullOrUndefined(launchArgs.scheme)) {
+            mobilePlatformOptions.scheme = launchArgs.scheme;
         }
 
-        if (!isNullOrUndefined(request.arguments.productName)) {
-            mobilePlatformOptions.productName = request.arguments.productName;
+        if (!isNullOrUndefined(launchArgs.productName)) {
+            mobilePlatformOptions.productName = launchArgs.productName;
         }
 
-        if (!isNullOrUndefined(request.arguments.launchActivity)) {
-            mobilePlatformOptions.debugLaunchActivity = request.arguments.launchActivity;
+        if (!isNullOrUndefined(launchArgs.launchActivity)) {
+            mobilePlatformOptions.debugLaunchActivity = launchArgs.launchActivity;
         }
 
-        if (request.arguments.type === "reactnativedirect") {
+        if (launchArgs.type === "reactnativedirect") {
             mobilePlatformOptions.isDirect = true;
         }
 
-        mobilePlatformOptions.packagerPort = SettingsHelper.getPackagerPort(request.arguments.cwd || request.arguments.program);
+        mobilePlatformOptions.packagerPort = SettingsHelper.getPackagerPort(launchArgs.cwd || launchArgs.program);
         const platformDeps: MobilePlatformDeps = {
             packager: this.packager,
         };
         const mobilePlatform = new PlatformResolver()
-            .resolveMobilePlatform(request.arguments.platform, mobilePlatformOptions, platformDeps);
+            .resolveMobilePlatform(launchArgs.platform, mobilePlatformOptions, platformDeps);
         return new Promise((resolve, reject) => {
             let extProps: any = {
                 platform: {
-                    value: request.arguments.platform,
+                    value: launchArgs.platform,
                     isPii: false,
                 },
             };
@@ -157,7 +157,7 @@ export class AppLauncher {
                 .then(versions => {
                     mobilePlatformOptions.reactNativeVersions = versions;
                     extProps = TelemetryHelper.addPropertyToTelemetryProperties(versions.reactNativeVersion, "reactNativeVersion", extProps);
-                    if (request.arguments.platform === "windows") {
+                    if (launchArgs.platform === "windows") {
                         if (ProjectVersionHelper.isVersionError(versions.reactNativeWindowsVersion)) {
                             throw ErrorHelper.getInternalError(InternalErrorCode.ReactNativeWindowsIsNotInstalled);
                         }
@@ -186,7 +186,7 @@ export class AppLauncher {
                             .then(() => {
                                 if (mobilePlatformOptions.isDirect) {
                                     generator.step("mobilePlatform.enableDirectDebuggingMode");
-                                    if (request.arguments.platform === "android") {
+                                    if (launchArgs.platform === "android") {
                                         this.logger.info(localize("PrepareHermesDebugging", "Prepare Hermes debugging (experimental)"));
                                     }
                                     return mobilePlatform.disableJSDebuggingMode();

--- a/src/extension/appLauncher.ts
+++ b/src/extension/appLauncher.ts
@@ -1,0 +1,268 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+import * as vscode from "vscode";
+import {Packager} from "../common/packager";
+import {RNPackageVersions} from "../common/projectVersionHelper";
+import {ExponentHelper} from "./exponent/exponentHelper";
+import {ReactDirManager} from "./reactDirManager";
+import {SettingsHelper} from "./settingsHelper";
+import {PackagerStatusIndicator} from "./packagerStatusIndicator";
+import {CommandExecutor} from "../common/commandExecutor";
+import {isNullOrUndefined} from "../common/utils";
+import {OutputChannelLogger} from "./log/OutputChannelLogger";
+import {MobilePlatformDeps} from "./generalMobilePlatform";
+import {PlatformResolver} from "./platformResolver";
+import {ProjectVersionHelper} from "../common/projectVersionHelper";
+import {TelemetryHelper} from "../common/telemetryHelper";
+import {ErrorHelper} from "../common/error/errorHelper";
+import {InternalErrorCode} from "../common/error/internalErrorCode";
+import {TargetPlatformHelper} from "../common/targetPlatformHelper";
+import {LogCatMonitor} from "./android/logCatMonitor";
+import {OpenFileRequest} from "../common/remoteExtension";
+import * as nls from "vscode-nls";
+const localize = nls.loadMessageBundle();
+
+export class AppLauncher {
+    private packager: Packager;
+    private exponentHelper: ExponentHelper;
+    private reactDirManager: ReactDirManager;
+    private workspaceFolder: vscode.WorkspaceFolder;
+    private reactNativeVersions?: RNPackageVersions;
+
+    private logger: OutputChannelLogger = OutputChannelLogger.getMainChannel();
+    private logCatMonitor: LogCatMonitor | null = null;
+
+    constructor(reactDirManager: ReactDirManager, workspaceFolder: vscode.WorkspaceFolder) {
+        const rootPath = workspaceFolder.uri.fsPath;
+        const projectRootPath = SettingsHelper.getReactNativeProjectRoot(rootPath);
+        this.exponentHelper = new ExponentHelper(rootPath, projectRootPath);
+        const packagerStatusIndicator: PackagerStatusIndicator = new PackagerStatusIndicator();
+        this.packager = new Packager(rootPath, projectRootPath, SettingsHelper.getPackagerPort(workspaceFolder.uri.fsPath), packagerStatusIndicator);
+        this.reactDirManager = reactDirManager;
+        this.workspaceFolder = workspaceFolder;
+    }
+
+    public getPackager(): Packager {
+        return this.packager;
+    }
+
+    public getWorkspaceFolderUri(): vscode.Uri {
+        return this.workspaceFolder.uri;
+    }
+
+    public getWorkspaceFolder(): vscode.WorkspaceFolder {
+        return this.workspaceFolder;
+    }
+
+    public getReactNativeVersions(): RNPackageVersions | undefined {
+        return this.reactNativeVersions;
+    }
+
+    public getExponentHelper(): ExponentHelper {
+        return this.exponentHelper;
+    }
+
+    public getReactDirManager(): ReactDirManager {
+        return this.reactDirManager;
+    }
+
+    public setReactNativeVersions(reactNativeVersions: RNPackageVersions): void {
+        this.reactNativeVersions = reactNativeVersions;
+    }
+
+    public dispose(): void {
+        this.packager.statusIndicator.dispose();
+        this.packager.stop(true);
+        this.stopMonitoringLogCat();
+    }
+
+    public stopMonitoringLogCat(): void {
+        if (this.logCatMonitor) {
+            this.logCatMonitor.dispose();
+            this.logCatMonitor = null;
+        }
+    }
+
+    public openFileAtLocation(openFileRequest: OpenFileRequest): Promise<void> {
+        const { filename, lineNumber } = openFileRequest;
+        return new Promise((resolve) => {
+            vscode.workspace.openTextDocument(vscode.Uri.file(filename))
+                .then((document: vscode.TextDocument) => {
+                    vscode.window.showTextDocument(document)
+                        .then((editor: vscode.TextEditor) => {
+                            let range = editor.document.lineAt(lineNumber - 1).range;
+                            editor.selection = new vscode.Selection(range.start, range.end);
+                            editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
+                            resolve();
+                        });
+                });
+        });
+    }
+
+    public getPackagerPort(projectFolder: string): number {
+        return SettingsHelper.getPackagerPort(projectFolder);
+    }
+
+    public launch(request: any): Promise<any> {
+        let mobilePlatformOptions = this.requestSetup(request.arguments);
+
+        // We add the parameter if it's defined (adapter crashes otherwise)
+        if (!isNullOrUndefined(request.arguments.logCatArguments)) {
+            mobilePlatformOptions.logCatArguments = [this.parseLogCatArguments(request.arguments.logCatArguments)];
+        }
+
+        if (!isNullOrUndefined(request.arguments.variant)) {
+            mobilePlatformOptions.variant = request.arguments.variant;
+        }
+
+        if (!isNullOrUndefined(request.arguments.scheme)) {
+            mobilePlatformOptions.scheme = request.arguments.scheme;
+        }
+
+        if (!isNullOrUndefined(request.arguments.productName)) {
+            mobilePlatformOptions.productName = request.arguments.productName;
+        }
+
+        if (!isNullOrUndefined(request.arguments.launchActivity)) {
+            mobilePlatformOptions.debugLaunchActivity = request.arguments.launchActivity;
+        }
+
+        if (request.arguments.type === "reactnativedirect") {
+            mobilePlatformOptions.isDirect = true;
+        }
+
+        mobilePlatformOptions.packagerPort = SettingsHelper.getPackagerPort(request.arguments.cwd || request.arguments.program);
+        const platformDeps: MobilePlatformDeps = {
+            packager: this.packager,
+        };
+        const mobilePlatform = new PlatformResolver()
+            .resolveMobilePlatform(request.arguments.platform, mobilePlatformOptions, platformDeps);
+        return new Promise((resolve, reject) => {
+            let extProps: any = {
+                platform: {
+                    value: request.arguments.platform,
+                    isPii: false,
+                },
+            };
+
+            if (mobilePlatformOptions.isDirect) {
+                extProps.isDirect = {
+                    value: true,
+                    isPii: false,
+                };
+            }
+
+            ProjectVersionHelper.getReactNativePackageVersionsFromNodeModules(mobilePlatformOptions.projectRoot, true)
+                .then(versions => {
+                    mobilePlatformOptions.reactNativeVersions = versions;
+                    extProps = TelemetryHelper.addPropertyToTelemetryProperties(versions.reactNativeVersion, "reactNativeVersion", extProps);
+                    if (request.arguments.platform === "windows") {
+                        if (ProjectVersionHelper.isVersionError(versions.reactNativeWindowsVersion)) {
+                            throw ErrorHelper.getInternalError(InternalErrorCode.ReactNativeWindowsIsNotInstalled);
+                        }
+                        extProps = TelemetryHelper.addPropertyToTelemetryProperties(versions.reactNativeWindowsVersion, "reactNativeWindowsVersion", extProps);
+                    }
+                    TelemetryHelper.generate("launch", extProps, (generator) => {
+                        generator.step("checkPlatformCompatibility");
+                        TargetPlatformHelper.checkTargetPlatformSupport(mobilePlatformOptions.platform);
+                        return mobilePlatform.beforeStartPackager()
+                            .then(() => {
+                                generator.step("startPackager");
+                                return mobilePlatform.startPackager();
+                            })
+                            .then(() => {
+                                // We've seen that if we don't prewarm the bundle cache, the app fails on the first attempt to connect to the debugger logic
+                                // and the user needs to Reload JS manually. We prewarm it to prevent that issue
+                                generator.step("prewarmBundleCache");
+                                this.logger.info(localize("PrewarmingBundleCache", "Prewarming bundle cache. This may take a while ..."));
+                                return mobilePlatform.prewarmBundleCache();
+                            })
+                            .then(() => {
+                                generator.step("mobilePlatform.runApp").add("target", mobilePlatformOptions.target, false);
+                                this.logger.info(localize("BuildingAndRunningApplication", "Building and running application."));
+                                return mobilePlatform.runApp();
+                            })
+                            .then(() => {
+                                if (mobilePlatformOptions.isDirect) {
+                                    generator.step("mobilePlatform.enableDirectDebuggingMode");
+                                    if (request.arguments.platform === "android") {
+                                        this.logger.info(localize("PrepareHermesDebugging", "Prepare Hermes debugging (experimental)"));
+                                    }
+                                    return mobilePlatform.disableJSDebuggingMode();
+                                }
+                                generator.step("mobilePlatform.enableJSDebuggingMode");
+                                this.logger.info(localize("EnableJSDebugging", "Enable JS Debugging"));
+                                return mobilePlatform.enableJSDebuggingMode();
+                            })
+                            .then(() => {
+                                resolve();
+                            })
+                            .catch(error => {
+                                generator.addError(error);
+                                this.logger.error(error);
+                                reject(error);
+                            });
+                    });
+                })
+                .catch(error => {
+                    if (error && error.errorCode) {
+                        if (error.errorCode === InternalErrorCode.ReactNativePackageIsNotInstalled) {
+                            TelemetryHelper.sendErrorEvent(
+                                "ReactNativePackageIsNotInstalled",
+                                ErrorHelper.getInternalError(InternalErrorCode.ReactNativePackageIsNotInstalled)
+                                );
+                        } else if (error.errorCode === InternalErrorCode.ReactNativeWindowsIsNotInstalled) {
+                            TelemetryHelper.sendErrorEvent(
+                                "ReactNativeWindowsPackageIsNotInstalled",
+                                ErrorHelper.getInternalError(InternalErrorCode.ReactNativeWindowsIsNotInstalled)
+                                );
+                        }
+                    }
+                    this.logger.error(error);
+                    reject(error);
+                });
+        });
+    }
+
+    private requestSetup(args: any): any {
+        const workspaceFolder: vscode.WorkspaceFolder = <vscode.WorkspaceFolder>vscode.workspace.getWorkspaceFolder(vscode.Uri.file(args.cwd || args.program));
+        const projectRootPath = this.getProjectRoot(args);
+        let mobilePlatformOptions: any = {
+            workspaceRoot: workspaceFolder.uri.fsPath,
+            projectRoot: projectRootPath,
+            platform: args.platform,
+            env: args.env,
+            envFile: args.envFile,
+            target: args.target || "simulator",
+        };
+
+        if (args.platform === "exponent") {
+            mobilePlatformOptions.expoHostType = args.expoHostType || "tunnel";
+        }
+
+        CommandExecutor.ReactNativeCommand = SettingsHelper.getReactNativeGlobalCommandName(workspaceFolder.uri);
+
+        if (!args.runArguments) {
+            let runArgs = SettingsHelper.getRunArgs(args.platform, args.target || "simulator", workspaceFolder.uri);
+            mobilePlatformOptions.runArguments = runArgs;
+        } else {
+            mobilePlatformOptions.runArguments = args.runArguments;
+        }
+
+        return mobilePlatformOptions;
+    }
+
+    private getProjectRoot(args: any): string {
+        return SettingsHelper.getReactNativeProjectRoot(args.cwd || args.program);
+    }
+
+    /**
+     * Parses log cat arguments to a string
+     */
+    private parseLogCatArguments(userProvidedLogCatArguments: any): string {
+        return Array.isArray(userProvidedLogCatArguments)
+            ? userProvidedLogCatArguments.join(" ") // If it's an array, we join the arguments
+            : userProvidedLogCatArguments; // If not, we leave it as-is
+    }
+}

--- a/src/extension/projectsStorage.ts
+++ b/src/extension/projectsStorage.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+import * as vscode from "vscode";
+import {AppLauncher} from "./appLauncher";
+
+export class ProjectsStorage {
+    public static readonly projectsCache: {[key: string]: AppLauncher} = {};
+
+    public static addFolder(workspaceFolder: vscode.WorkspaceFolder, appLauncher: AppLauncher): void {
+        this.projectsCache[workspaceFolder.uri.fsPath] = appLauncher;
+    }
+
+    public static getFolder(workspaceFolder: vscode.WorkspaceFolder): AppLauncher {
+        return this.projectsCache[workspaceFolder.uri.fsPath];
+    }
+
+    public static delFolder(workspaceFolder: vscode.WorkspaceFolder): void {
+        delete this.projectsCache[workspaceFolder.uri.fsPath];
+    }
+}

--- a/src/extension/rn-extension.ts
+++ b/src/extension/rn-extension.ts
@@ -17,21 +17,20 @@ import * as semver from "semver";
 
 import {FileSystem} from "../common/node/fileSystem";
 import {CommandPaletteHandler} from "./commandPaletteHandler";
-import {Packager} from "../common/packager";
 import {EntryPointHandler, ProcessType} from "../common/entryPointHandler";
 import {ErrorHelper} from "../common/error/errorHelper";
 import {InternalError} from "../common/error/internalError";
 import {InternalErrorCode} from "../common/error/internalErrorCode";
 import {SettingsHelper} from "./settingsHelper";
-import {PackagerStatusIndicator} from "./packagerStatusIndicator";
 import {ProjectVersionHelper} from "../common/projectVersionHelper";
 import {ReactDirManager} from "./reactDirManager";
 import {Telemetry} from "../common/telemetry";
 import {TelemetryHelper, ICommandTelemetryProperties} from "../common/telemetryHelper";
-import {ExtensionServer} from "./extensionServer";
 import {OutputChannelLogger} from "./log/OutputChannelLogger";
-import {ExponentHelper} from "./exponent/exponentHelper";
 import {ReactNativeDebugConfigProvider} from "./debugConfigurationProvider";
+import {RNDebugAdapterDescriptorFactory} from "./rnDebugAdapterDescriptorFactory";
+import {ProjectsStorage} from "./projectsStorage";
+import {AppLauncher} from "./appLauncher";
 import * as nls from "vscode-nls";
 const localize = nls.loadMessageBundle();
 
@@ -67,6 +66,10 @@ export function activate(context: vscode.ExtensionContext): Q.Promise<void> {
         context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((event) => onChangeConfiguration(context)));
 
         debugConfigProvider = vscode.debug.registerDebugConfigurationProvider("reactnative", configProvider);
+
+        const rnFactory = new RNDebugAdapterDescriptorFactory();
+        context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory("reactnative", rnFactory));
+
         let activateExtensionEvent = TelemetryHelper.createTelemetryEvent("activate");
         Telemetry.send(activateExtensionEvent);
         let promises: any = [];
@@ -147,19 +150,9 @@ function onFolderAdded(context: vscode.ExtensionContext, folder: vscode.Workspac
                     let reactDirManager = new ReactDirManager(rootPath);
                     return setupAndDispose(reactDirManager, context)
                         .then(() => {
-                            let exponentHelper: ExponentHelper = new ExponentHelper(rootPath, projectRootPath);
-                            let packagerStatusIndicator: PackagerStatusIndicator = new PackagerStatusIndicator();
-                            let packager: Packager = new Packager(rootPath, projectRootPath, SettingsHelper.getPackagerPort(folder.uri.fsPath), packagerStatusIndicator);
-                            let extensionServer: ExtensionServer = new ExtensionServer(projectRootPath, packager);
+                            ProjectsStorage.addFolder(folder, new AppLauncher(reactDirManager, folder));
 
-                            CommandPaletteHandler.addFolder(folder, {
-                                packager,
-                                exponentHelper,
-                                reactDirManager,
-                                extensionServer,
-                            });
-
-                            return setupAndDispose(extensionServer, context).then(() => { });
+                            return void 0;
                         });
                 }));
                 promises.push(entryPointHandler.runFunction("debugger.setupNodeDebuggerLocation",
@@ -175,14 +168,14 @@ function onFolderAdded(context: vscode.ExtensionContext, folder: vscode.Workspac
 }
 
 function onFolderRemoved(context: vscode.ExtensionContext, folder: vscode.WorkspaceFolder): void {
-    let project = CommandPaletteHandler.getFolder(folder);
-    Object.keys(project).forEach((key) => {
-        if (project[key].dispose) {
-            project[key].dispose();
+    let appLauncher = ProjectsStorage.getFolder(folder);
+    Object.keys(appLauncher).forEach((key) => {
+        if (appLauncher[key].dispose) {
+            appLauncher[key].dispose();
         }
     });
     outputChannelLogger.debug(`Delete project: ${folder.uri.fsPath}`);
-    CommandPaletteHandler.delFolder(folder);
+    ProjectsStorage.delFolder(folder);
 
     try { // Preventing memory leaks
         context.subscriptions.forEach((element: any, index: number) => {

--- a/src/extension/rnDebugAdapterDescriptorFactory.ts
+++ b/src/extension/rnDebugAdapterDescriptorFactory.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+import * as vscode from "vscode";
+import * as Net from "net";
+import { RNDebugSession } from "../debugger/rnDebugSession";
+
+export class RNDebugAdapterDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {
+
+    private server?: Net.Server;
+
+    public createDebugAdapterDescriptor(session: vscode.DebugSession, executable: vscode.DebugAdapterExecutable | undefined): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+
+        if (!this.server) {
+            // start listening on a random port
+            this.server = Net.createServer(socket => {
+                const rnDebugSession = new RNDebugSession(session);
+                rnDebugSession.setRunAsServer(true);
+                rnDebugSession.start(<NodeJS.ReadableStream>socket, socket);
+            }).listen(0);
+        }
+
+        // make VS Code connect to debug server
+        return new vscode.DebugAdapterServer((<Net.AddressInfo>this.server.address()).port);
+    }
+
+    public dispose() {
+        if (this.server) {
+            this.server.close();
+        }
+    }
+}


### PR DESCRIPTION
The list of changes:

* Refactored projects caching - created a separate class that intended to store projects data and provide access to them
* Implemented Debug Adapter Server within Debug Adapter Descriptor Factory approach
* Added new Debug Session class implementation intended to be used with [js-debug extension](https://github.com/microsoft/vscode-js-debug). So now js-debug attach scenario is called from our debug session where we make only some preparations for debugging.
