### PR TITLE
Fix port definition on attaching and enhance logging

### DIFF
--- a/src/cdp-proxy/reactNativeCDPProxy.ts
+++ b/src/cdp-proxy/reactNativeCDPProxy.ts
@@ -81,7 +81,7 @@ export class ReactNativeCDPProxy {
     }
 
     private handleDebuggerTargetCommand(evt: IProtocolCommand) {
-        this.logger.logWithTag(this.PROXY_LOG_TAGS.DEBUGGER_COMMAND, JSON.stringify(evt, null , 2), this.logLevel);
+        this.logger.logWithCustomTag(this.PROXY_LOG_TAGS.DEBUGGER_COMMAND, JSON.stringify(evt, null , 2), this.logLevel);
         this.applicationTarget.send(evt);
     }
 
@@ -89,7 +89,7 @@ export class ReactNativeCDPProxy {
         if (evt.method === "Debugger.paused" && this.firstStop) {
             evt.params = this.handleAppBundleFirstPauseEvent(evt);
         }
-        this.logger.logWithTag(this.PROXY_LOG_TAGS.APPLICATION_COMMAND, JSON.stringify(evt, null , 2), this.logLevel);
+        this.logger.logWithCustomTag(this.PROXY_LOG_TAGS.APPLICATION_COMMAND, JSON.stringify(evt, null , 2), this.logLevel);
         this.debuggerTarget.send(evt);
     }
 
@@ -110,12 +110,12 @@ export class ReactNativeCDPProxy {
     }
 
     private handleDebuggerTargetReply(evt: IProtocolError | IProtocolSuccess) {
-        this.logger.logWithTag(this.PROXY_LOG_TAGS.DEBUGGER_REPLY, JSON.stringify(evt, null , 2), this.logLevel);
+        this.logger.logWithCustomTag(this.PROXY_LOG_TAGS.DEBUGGER_REPLY, JSON.stringify(evt, null , 2), this.logLevel);
         this.applicationTarget.send(evt);
     }
 
     private handleApplicationTargetReply(evt: IProtocolError | IProtocolSuccess) {
-        this.logger.logWithTag(this.PROXY_LOG_TAGS.APPLICATION_REPLY, JSON.stringify(evt, null , 2), this.logLevel);
+        this.logger.logWithCustomTag(this.PROXY_LOG_TAGS.APPLICATION_REPLY, JSON.stringify(evt, null , 2), this.logLevel);
         this.debuggerTarget.send(evt);
     }
 

--- a/src/cdp-proxy/reactNativeCDPProxy.ts
+++ b/src/cdp-proxy/reactNativeCDPProxy.ts
@@ -99,7 +99,7 @@ export class ReactNativeCDPProxy {
      *  and wait for the adapter to receive a signal to stop on that statement
      *  and then change pause reason to `Break on start` so js-debug can process all breakpoints in the bundle and
      *  continue the code execution using `continueOnAttach` flag
-     **/
+     */
     private handleAppBundleFirstPauseEvent(evt: IProtocolCommand): any {
         let params: any = evt.params;
         if (params.reason && params.reason === "other") {

--- a/src/cdp-proxy/reactNativeCDPProxy.ts
+++ b/src/cdp-proxy/reactNativeCDPProxy.ts
@@ -12,6 +12,7 @@ import {
 import { URL } from "url";
 import { IncomingMessage } from "http";
 import { OutputChannelLogger } from "../extension/log/OutputChannelLogger";
+import { LogLevel } from "../extension/log/LogHelper";
 
 export class ReactNativeCDPProxy {
     private server: Server | null;
@@ -20,6 +21,7 @@ export class ReactNativeCDPProxy {
     private debuggerTarget: Connection;
     private applicationTarget: Connection;
     private logger: OutputChannelLogger;
+    private logLevel: LogLevel;
 
     private readonly PROXY_LOG_TAGS = {
         DEBUGGER_COMMAND: "Command Debugger To Target",
@@ -28,14 +30,11 @@ export class ReactNativeCDPProxy {
         APPLICATION_REPLY: "Reply From Target To Debugger",
     };
 
-    constructor(port: number, hostAddress: string, logsEnabled: boolean) {
+    constructor(port: number, hostAddress: string, logLevel: LogLevel) {
         this.port = port;
         this.hostAddress = hostAddress;
-        this.logger = OutputChannelLogger.getChannel("RN CDP Proxy", true, false, true);
-
-        if (logsEnabled) {
-            this.logger.enableTags();
-        }
+        this.logger = OutputChannelLogger.getChannel("React Native Chrome Proxy", true, false, true);
+        this.logLevel = logLevel;
     }
 
     public createServer(): Promise<void> {
@@ -81,22 +80,22 @@ export class ReactNativeCDPProxy {
     }
 
     private handleDebuggerTargetCommand(evt: IProtocolCommand) {
-        this.logger.logWithTag(this.PROXY_LOG_TAGS.DEBUGGER_COMMAND, JSON.stringify(evt, null , 2));
+        this.logger.logWithTag(this.PROXY_LOG_TAGS.DEBUGGER_COMMAND, JSON.stringify(evt, null , 2), this.logLevel);
         this.applicationTarget.send(evt);
     }
 
     private handleApplicationTargetCommand(evt: IProtocolCommand) {
-        this.logger.logWithTag(this.PROXY_LOG_TAGS.APPLICATION_COMMAND, JSON.stringify(evt, null , 2));
+        this.logger.logWithTag(this.PROXY_LOG_TAGS.APPLICATION_COMMAND, JSON.stringify(evt, null , 2), this.logLevel);
         this.debuggerTarget.send(evt);
     }
 
     private handleDebuggerTargetReply(evt: IProtocolError | IProtocolSuccess) {
-        this.logger.logWithTag(this.PROXY_LOG_TAGS.DEBUGGER_REPLY, JSON.stringify(evt, null , 2));
+        this.logger.logWithTag(this.PROXY_LOG_TAGS.DEBUGGER_REPLY, JSON.stringify(evt, null , 2), this.logLevel);
         this.applicationTarget.send(evt);
     }
 
     private handleApplicationTargetReply(evt: IProtocolError | IProtocolSuccess) {
-        this.logger.logWithTag(this.PROXY_LOG_TAGS.APPLICATION_REPLY, JSON.stringify(evt, null , 2));
+        this.logger.logWithTag(this.PROXY_LOG_TAGS.APPLICATION_REPLY, JSON.stringify(evt, null , 2), this.logLevel);
         this.debuggerTarget.send(evt);
     }
 

--- a/src/cdp-proxy/reactNativeCDPProxy.ts
+++ b/src/cdp-proxy/reactNativeCDPProxy.ts
@@ -31,7 +31,7 @@ export class ReactNativeCDPProxy {
         APPLICATION_REPLY: "Reply From Target To Debugger",
     };
 
-    constructor(port: number, hostAddress: string, logLevel: LogLevel) {
+    constructor(hostAddress: string, port: number, logLevel: LogLevel) {
         this.port = port;
         this.hostAddress = hostAddress;
         this.logger = OutputChannelLogger.getChannel("React Native Chrome Proxy", true, false, true);

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -6,9 +6,9 @@ export function isNullOrUndefined(value: any): boolean {
 }
 
 export function getFormattedTimeString(date: Date): string {
-    const hourString = _padZeroes(2, String(date.getUTCHours()));
-    const minuteString = _padZeroes(2, String(date.getUTCMinutes()));
-    const secondString = _padZeroes(2, String(date.getUTCSeconds()));
+    const hourString = padZeroes(2, String(date.getUTCHours()));
+    const minuteString = padZeroes(2, String(date.getUTCMinutes()));
+    const secondString = padZeroes(2, String(date.getUTCSeconds()));
     return `${hourString}:${minuteString}:${secondString}`;
 }
 
@@ -20,7 +20,7 @@ export function getFormattedDatetimeString(date: Date): string {
     return `${getFormattedDateString(date)} ${getFormattedTimeString(date)}`;
 }
 
-function _padZeroes(minDesiredLength: number, numberToPad: string): string {
+function padZeroes(minDesiredLength: number, numberToPad: string): string {
     if (numberToPad.length >= minDesiredLength) {
         return numberToPad;
     } else {

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -4,3 +4,26 @@
 export function isNullOrUndefined(value: any): boolean {
     return typeof value === "undefined" || value === null;
 }
+
+export function getFormattedTimeString(date: Date): string {
+    const hourString = _padZeroes(2, String(date.getUTCHours()));
+    const minuteString = _padZeroes(2, String(date.getUTCMinutes()));
+    const secondString = _padZeroes(2, String(date.getUTCSeconds()));
+    return `${hourString}:${minuteString}:${secondString}`;
+}
+
+export function getFormattedDateString(date: Date): string {
+    return date.getUTCFullYear() + "-" + `${date.getUTCMonth() + 1}` + "-" + date.getUTCDate();
+}
+
+export function getFormattedDatetimeString(date: Date): string {
+    return `${getFormattedDateString(date)} ${getFormattedTimeString(date)}`;
+}
+
+function _padZeroes(minDesiredLength: number, numberToPad: string): string {
+    if (numberToPad.length >= minDesiredLength) {
+        return numberToPad;
+    } else {
+        return String("0".repeat(minDesiredLength) + numberToPad).slice(-minDesiredLength);
+    }
+}

--- a/src/debugger/rnDebugSession.ts
+++ b/src/debugger/rnDebugSession.ts
@@ -99,12 +99,7 @@ export class RNDebugSession extends LoggingDebugSession {
                             extProps = TelemetryHelper.addPropertyToTelemetryProperties(versions.reactNativeWindowsVersion, "reactNativeWindowsVersion", extProps);
                         }
                         return TelemetryHelper.generate("attach", extProps, (generator) => {
-                            this.rnCdpProxy = new ReactNativeCDPProxy(
-                                this.CDP_PROXY_PORT,
-                                this.CDP_PROXY_HOST_ADDRESS,
-                                this.cdpProxyLogLevel === LogLevel.Info
-                                );
-
+                            this.rnCdpProxy = new ReactNativeCDPProxy(this.CDP_PROXY_PORT, this.CDP_PROXY_HOST_ADDRESS, this.cdpProxyLogLevel);
                             attachArgs.port = attachArgs.port || this.appLauncher.getPackagerPort(attachArgs.cwd);
                             return this.rnCdpProxy.createServer()
                                 .then(() => {
@@ -200,10 +195,10 @@ export class RNDebugSession extends LoggingDebugSession {
             if (logLevel) {
                 logLevel = logLevel.replace(logLevel[0], logLevel[0].toUpperCase());
                 logger.setup(Logger.LogLevel[logLevel], chromeDebugCoreLogs || false);
-                this.cdpProxyLogLevel = LogLevel[logLevel] === LogLevel.Verbose ? LogLevel.Info : LogLevel.None;
+                this.cdpProxyLogLevel = LogLevel[logLevel] === LogLevel.Verbose ? LogLevel.Tag : LogLevel.None;
             } else {
                 logger.setup(Logger.LogLevel.Log, chromeDebugCoreLogs || false);
-                this.cdpProxyLogLevel = LogHelper.LOG_LEVEL === LogLevel.Trace ? LogLevel.Info : LogLevel.None;
+                this.cdpProxyLogLevel = LogHelper.LOG_LEVEL === LogLevel.Trace ? LogLevel.Tag : LogLevel.None;
             }
 
             if (!args.sourceMaps) {

--- a/src/debugger/rnDebugSession.ts
+++ b/src/debugger/rnDebugSession.ts
@@ -99,7 +99,12 @@ export class RNDebugSession extends LoggingDebugSession {
                             extProps = TelemetryHelper.addPropertyToTelemetryProperties(versions.reactNativeWindowsVersion, "reactNativeWindowsVersion", extProps);
                         }
                         return TelemetryHelper.generate("attach", extProps, (generator) => {
-                            this.rnCdpProxy = new ReactNativeCDPProxy(this.CDP_PROXY_PORT, this.CDP_PROXY_HOST_ADDRESS, this.cdpProxyLogLevel);
+                            this.rnCdpProxy = new ReactNativeCDPProxy(
+                                this.CDP_PROXY_PORT,
+                                this.CDP_PROXY_HOST_ADDRESS,
+                                this.cdpProxyLogLevel === LogLevel.Info
+                                );
+
                             attachArgs.port = attachArgs.port || this.appLauncher.getPackagerPort(attachArgs.cwd);
                             return this.rnCdpProxy.createServer()
                                 .then(() => {
@@ -115,7 +120,8 @@ export class RNDebugSession extends LoggingDebugSession {
                                         attachArgs,
                                         sourcesStoragePath,
                                         this.projectRootPath,
-                                        undefined);
+                                        undefined
+                                        );
 
                                     this.appWorker.on("connected", (port: number) => {
                                         logger.log(localize("DebuggerWorkerLoadedRuntimeOnPort", "Debugger worker loaded runtime on port {0}", port));

--- a/src/debugger/rnDebugSession.ts
+++ b/src/debugger/rnDebugSession.ts
@@ -196,10 +196,10 @@ export class RNDebugSession extends LoggingDebugSession {
             if (logLevel) {
                 logLevel = logLevel.replace(logLevel[0], logLevel[0].toUpperCase());
                 logger.setup(Logger.LogLevel[logLevel], chromeDebugCoreLogs || false);
-                this.cdpProxyLogLevel = LogLevel[logLevel] === LogLevel.Verbose ? LogLevel.Tag : LogLevel.None;
+                this.cdpProxyLogLevel = LogLevel[logLevel] === LogLevel.Verbose ? LogLevel.Custom : LogLevel.None;
             } else {
                 logger.setup(Logger.LogLevel.Log, chromeDebugCoreLogs || false);
-                this.cdpProxyLogLevel = LogHelper.LOG_LEVEL === LogLevel.Trace ? LogLevel.Tag : LogLevel.None;
+                this.cdpProxyLogLevel = LogHelper.LOG_LEVEL === LogLevel.Trace ? LogLevel.Custom : LogLevel.None;
             }
 
             if (!args.sourceMaps) {

--- a/src/debugger/rnDebugSession.ts
+++ b/src/debugger/rnDebugSession.ts
@@ -99,7 +99,7 @@ export class RNDebugSession extends LoggingDebugSession {
                             extProps = TelemetryHelper.addPropertyToTelemetryProperties(versions.reactNativeWindowsVersion, "reactNativeWindowsVersion", extProps);
                         }
                         return TelemetryHelper.generate("attach", extProps, (generator) => {
-                            this.rnCdpProxy = new ReactNativeCDPProxy(this.CDP_PROXY_PORT, this.CDP_PROXY_HOST_ADDRESS, this.cdpProxyLogLevel);
+                            this.rnCdpProxy = new ReactNativeCDPProxy(this.CDP_PROXY_HOST_ADDRESS, this.CDP_PROXY_PORT, this.cdpProxyLogLevel);
                             attachArgs.port = attachArgs.port || this.appLauncher.getPackagerPort(attachArgs.cwd);
                             return this.rnCdpProxy.createServer()
                                 .then(() => {

--- a/src/debugger/rnDebugSession.ts
+++ b/src/debugger/rnDebugSession.ts
@@ -49,6 +49,7 @@ export class RNDebugSession extends LoggingDebugSession {
 
     constructor(private session: vscode.DebugSession) {
         super();
+        this.isSettingsInitialized = false;
     }
 
     protected initializeRequest(response: DebugProtocol.InitializeResponse, args: DebugProtocol.InitializeRequestArguments): void {
@@ -99,6 +100,7 @@ export class RNDebugSession extends LoggingDebugSession {
                         }
                         return TelemetryHelper.generate("attach", extProps, (generator) => {
                             this.rnCdpProxy = new ReactNativeCDPProxy(this.CDP_PROXY_PORT, this.CDP_PROXY_HOST_ADDRESS, this.cdpProxyLogLevel);
+                            attachArgs.port = attachArgs.port || this.appLauncher.getPackagerPort(attachArgs.cwd);
                             return this.rnCdpProxy.createServer()
                                 .then(() => {
                                     logger.log(localize("StartingDebuggerAppWorker", "Starting debugger app worker."));

--- a/src/extension/log/LogHelper.ts
+++ b/src/extension/log/LogHelper.ts
@@ -14,6 +14,7 @@ export enum LogLevel {
     Warning = 4,
     Error = 5,
     Verbose = 6,
+    Tag = 7,
 }
 
 export interface ILogger {

--- a/src/extension/log/LogHelper.ts
+++ b/src/extension/log/LogHelper.ts
@@ -14,7 +14,7 @@ export enum LogLevel {
     Warning = 4,
     Error = 5,
     Verbose = 6,
-    Tag = 7,
+    Custom = 7,
 }
 
 export interface ILogger {

--- a/src/extension/log/OutputChannelLogger.ts
+++ b/src/extension/log/OutputChannelLogger.ts
@@ -74,12 +74,12 @@ export class OutputChannelLogger implements ILogger {
         }
     }
 
-    public logWithTag(tag: string, message: string, level: LogLevel): void {
+    public logWithCustomTag(tag: string, message: string, level: LogLevel): void {
         if (LogHelper.LOG_LEVEL === LogLevel.None) {
             return;
         }
 
-        if (level === LogLevel.Tag) {
+        if (level === LogLevel.Custom) {
             message = OutputChannelLogger.getFormattedMessage(message, tag, this.logTimestamps);
             this.channel.appendLine(message);
             if (this.channelLogFileStream) {

--- a/src/extension/log/OutputChannelLogger.ts
+++ b/src/extension/log/OutputChannelLogger.ts
@@ -20,7 +20,6 @@ export class OutputChannelLogger implements ILogger {
     private channelLogFileStream: fs.WriteStream;
     private outputChannel: vscode.OutputChannel;
     private logTimestamps: boolean;
-    private tagsAllowed: boolean;
     private static forbiddenFileNameSymbols: RegExp = /\W/gi;
 
     public static disposeChannel(channelName: string): void {
@@ -46,7 +45,6 @@ export class OutputChannelLogger implements ILogger {
 
     constructor(public readonly channelName: string, lazy: boolean = false, private preserveFocus: boolean = false, logTimestamps: boolean = false) {
         this.logTimestamps = logTimestamps;
-        this.tagsAllowed = false;
         const channelLogFolder = getLoggingDirectory();
         if (channelLogFolder) {
             const filename = channelName.replace(OutputChannelLogger.forbiddenFileNameSymbols, "");
@@ -60,14 +58,6 @@ export class OutputChannelLogger implements ILogger {
             this.channel = vscode.window.createOutputChannel(this.channelName);
             this.channel.show(this.preserveFocus);
         }
-    }
-
-    public enableTags(): void {
-        this.tagsAllowed = true;
-    }
-
-    public disableTags(): void {
-        this.tagsAllowed = false;
     }
 
     public log(message: string, level: LogLevel): void {
@@ -84,12 +74,12 @@ export class OutputChannelLogger implements ILogger {
         }
     }
 
-    public logWithTag(tag: string, message: string): void {
+    public logWithTag(tag: string, message: string, level: LogLevel): void {
         if (LogHelper.LOG_LEVEL === LogLevel.None) {
             return;
         }
 
-        if (this.tagsAllowed) {
+        if (level === LogLevel.Tag) {
             message = OutputChannelLogger.getFormattedMessage(message, tag, this.logTimestamps);
             this.channel.appendLine(message);
             if (this.channelLogFileStream) {


### PR DESCRIPTION
- Now it's possible to add timestamp to a log message and use custom tags as well as log levels tags for logging, an output will look something like this:
```
[2020-03-03 22:08:01] [My Tag] message"
```
- Added port definition during attach event handling
