### PR TITLE
feat: issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -1,0 +1,71 @@
+---
+name: "\U0001F41EBug report"
+about: Report a bug
+title: "[Bug] Bug description"
+labels: "bug"
+---
+
+# 🐛 What is the bug? How can we reproduce it?
+
+Please put here any steps, code or any information that can help us
+reproduce the error on our side so we can fix it:
+
+1. Step 1
+2. Step 2
+
+## Expected behavior
+
+What were you expecting to happen?
+
+## Debug output
+
+<details>
+<summary>Debug Console</summary>
+
+```text
+
+PASTE OUTPUT OF DEBUG CONSOLE (View -> Toggle Debug Console)
+
+```
+</details>
+
+<details>
+<summary>React Native output channel</summary>
+
+```text
+
+PASTE OUTPUT OF REACT-NATIVE OUTPUT CHANNEL (View -> Toggle Output -> Select React-Native in ListBox)
+
+```
+</details>
+
+
+<details>
+<summary>Developer Tools console</summary>
+
+```text
+
+PASTE OUTPUT OF DEVELOPER TOOLS CONSOLE (Help -> Toggle Developer Tools -> Select Console tab)
+
+```
+</details>
+
+
+## Environment
+
+Please tell us about your system and your project:
+
+* `npx react-native doctor`:
+
+```text
+PASTE OUTPUT OF `npx react-native doctor`
+```
+
+* `envinfo`:
+
+```text
+PASTE OUTPUT OF `npx envinfo`
+```
+
+* React Native Tools extension version: VERSION
+* Expo SDK version (if applicable): VERSION

--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -55,10 +55,10 @@ PASTE OUTPUT OF DEVELOPER TOOLS CONSOLE (Help -> Toggle Developer Tools -> Selec
 
 Please tell us about your system and your project:
 
-* `npx react-native doctor`:
+* `npx react-native doctor` or `npx expo doctor` if your project is using Expo:
 
 ```text
-PASTE OUTPUT OF `npx react-native doctor`
+PASTE OUTPUT OF `npx react-native doctor` or `npx expo doctor`
 ```
 
 * `envinfo`:

--- a/.github/ISSUE_TEMPLATE/2-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.md
@@ -1,0 +1,14 @@
+---
+name: "\U0001F680Feature request"
+about: Suggest a feature
+title: "[Feature] Feature description"
+labels: "enhancement"
+---
+
+# 🚀 Feature request
+
+What do you want to be added?
+
+## What scenarios will this solve?
+
+What will this allow you to do? Will this benefit other developers?


### PR DESCRIPTION
Added a couple issue templates so users can report issues or new features more easily.

When clicking in "new issue" the should see a menu to choose the template similar to the following (this is from another repo):

![image](https://user-images.githubusercontent.com/606594/81564362-794b5880-934c-11ea-97ca-fffd0a85fe94.png)

Feel free to suggest any other fields or information that might be useful!
