### PR TITLE
Stabilize smoke UI tests

### DIFF
--- a/test/smoke/automation/src/code.ts
+++ b/test/smoke/automation/src/code.ts
@@ -192,7 +192,7 @@ async function poll<T>(
     acceptFn: (result: T) => boolean,
     timeoutMessage: string,
     retryCount: number = 2000,
-    retryInterval: number = 500 // millis
+    retryInterval: number = 100 // millis
 ): Promise<T> {
     let trial = 1;
     let lastError: string = "";

--- a/test/smoke/automation/src/code.ts
+++ b/test/smoke/automation/src/code.ts
@@ -192,7 +192,7 @@ async function poll<T>(
     acceptFn: (result: T) => boolean,
     timeoutMessage: string,
     retryCount: number = 2000,
-    retryInterval: number = 100 // millis
+    retryInterval: number = 500 // millis
 ): Promise<T> {
     let trial = 1;
     let lastError: string = "";

--- a/test/smoke/package/src/expoDebug.test.ts
+++ b/test/smoke/package/src/expoDebug.test.ts
@@ -143,12 +143,16 @@ export function startExpoTests(
             app = await vscodeManager.runVSCode(workspacePath, testName);
             SmokeTestLogger.info(`${testName}: ${workspacePath} directory is opened in VS Code`);
             await app.workbench.quickaccess.openFile(appFileName);
+            await sleep(1);
             await app.workbench.editors.scrollTop();
             SmokeTestLogger.info(`${testName}: ${appFileName} file is opened`);
+
+            await sleep(1);
             await app.workbench.debug.setBreakpointOnLine(ExpoSetBreakpointOnLine);
             SmokeTestLogger.info(
                 `${testName}: Breakpoint is set on line ${ExpoSetBreakpointOnLine}`,
             );
+
             SmokeTestLogger.info(`${testName}: Chosen debug configuration: ${debugConfigName}`);
             if (process.env.REACT_NATIVE_TOOLS_LOGS_DIR) {
                 logFilePath = path.join(
@@ -158,6 +162,7 @@ export function startExpoTests(
             } else {
                 assert.fail("REACT_NATIVE_TOOLS_LOGS_DIR is not defined");
             }
+
             await runExpoDebugScenario(
                 logFilePath,
                 testName,
@@ -166,8 +171,11 @@ export function startExpoTests(
                 triesToLaunchApp,
             );
 
+            await sleep(1);
             await app.workbench.editors.waitForTab("Expo QR Code", false, true);
+            await sleep(1);
             await app.workbench.editors.waitForActiveTab("Expo QR Code", false, true);
+            await sleep(1);
             SmokeTestLogger.info(`${testName}: 'Expo QR Code' tab found`);
 
             let expoURL = findExpoURLInLogFile();
@@ -236,7 +244,10 @@ export function startExpoTests(
                 `looking for ${appFileName} and line ${ExpoSetBreakpointOnLine}`,
             );
             SmokeTestLogger.info(`${testName}: Stack frame found`);
+
+            await sleep(1);
             await app.workbench.debug.stepOver();
+
             // Wait for debug string to be rendered in debug console
             await sleep(SmokeTestsConstants.debugConsoleSearchTimeout);
             SmokeTestLogger.info(
@@ -245,6 +256,7 @@ export function startExpoTests(
             let found = await app.workbench.debug.waitForOutput(output =>
                 output.some(line => line.indexOf("Test output from debuggee") >= 0),
             );
+
             assert.notStrictEqual(
                 found,
                 false,

--- a/test/smoke/package/src/helpers/smokeTestsConstants.ts
+++ b/test/smoke/package/src/helpers/smokeTestsConstants.ts
@@ -35,7 +35,7 @@ export class SmokeTestsConstants {
     // Timeout for iOS testing
     public static iosTestTimeout = 700 * 1000;
     // Timeout for Android testing
-    public static androidTestTimeout = 400 * 1000;
+    public static androidTestTimeout = 700 * 1000;
     // Timeout for Android testing
     public static hermesTestTimeout = 15 * 60 * 1000;
     // Timeout for smoke tests setup

--- a/test/smoke/package/src/helpers/utilities.ts
+++ b/test/smoke/package/src/helpers/utilities.ts
@@ -287,3 +287,24 @@ export async function smokeTestFail(message: string): Promise<void> {
     await AppiumHelper.terminateAppium();
     process.exit(1);
 }
+
+export async function retryAsyncFunction(fn: Function, retryCount: number = 1): Promise<void> {
+    let success: boolean;
+    let tryTimes: number = retryCount + 1;
+
+    while (tryTimes > 0) {
+        success = true;
+
+        try {
+            await fn();
+        } catch (error) {
+            SmokeTestLogger.error(`Error: ${error}`);
+            success = false;
+            tryTimes--;
+        }
+
+        if (success) {
+            return;
+        }
+    }
+}

--- a/test/smoke/package/src/helpers/utilities.ts
+++ b/test/smoke/package/src/helpers/utilities.ts
@@ -288,7 +288,10 @@ export async function smokeTestFail(message: string): Promise<void> {
     process.exit(1);
 }
 
-export async function retryAsyncFunction(fn: Function, retryCount: number = 1): Promise<void> {
+export async function retryAsyncFunction(
+    fn: typeof Function,
+    retryCount: number = 1,
+): Promise<void> {
     let success: boolean;
     let tryTimes: number = retryCount + 1;
 

--- a/test/smoke/package/src/helpers/utilities.ts
+++ b/test/smoke/package/src/helpers/utilities.ts
@@ -288,10 +288,7 @@ export async function smokeTestFail(message: string): Promise<void> {
     process.exit(1);
 }
 
-export async function retryAsyncFunction(
-    fn: any,
-    retryCount: number = 1,
-): Promise<void> {
+export async function retryAsyncFunction(fn: any, retryCount: number = 1): Promise<void> {
     let success: boolean;
     let tryTimes: number = retryCount + 1;
 

--- a/test/smoke/package/src/helpers/utilities.ts
+++ b/test/smoke/package/src/helpers/utilities.ts
@@ -291,7 +291,7 @@ export async function smokeTestFail(message: string): Promise<void> {
 export async function retryAsyncFunction(
     fn: typeof Function,
     retryCount: number = 1,
-): Promise<void> {
+): Promise<any> {
     let success: boolean;
     let tryTimes: number = retryCount + 1;
 

--- a/test/smoke/package/src/helpers/utilities.ts
+++ b/test/smoke/package/src/helpers/utilities.ts
@@ -304,10 +304,13 @@ export async function retryAsyncFunction(
             SmokeTestLogger.error(`Error: ${error}`);
             success = false;
             tryTimes--;
+            if (tryTimes === 0) {
+                throw error;
+            }
         }
 
         if (success) {
-            return;
+            break;
         }
     }
 }

--- a/test/smoke/package/src/helpers/utilities.ts
+++ b/test/smoke/package/src/helpers/utilities.ts
@@ -289,9 +289,9 @@ export async function smokeTestFail(message: string): Promise<void> {
 }
 
 export async function retryAsyncFunction(
-    fn: typeof Function,
+    fn: any,
     retryCount: number = 1,
-): Promise<any> {
+): Promise<void> {
     let success: boolean;
     let tryTimes: number = retryCount + 1;
 

--- a/test/smoke/package/src/nativeDebug.test.ts
+++ b/test/smoke/package/src/nativeDebug.test.ts
@@ -16,7 +16,7 @@ const AndroidRNDebugConfigName = "Debug Android";
 const RnAppBundleId = "org.reactjs.native.example.latestRNApp";
 const IosRNDebugConfigName = "Debug classic iOS";
 
-const appFileName = "App.js";
+const APP_FILE_NAME = "App.js";
 const RNSetBreakpointOnLine = 1;
 
 // Time for Android Debug Test before it reaches timeout
@@ -45,10 +45,10 @@ export function startReactNativeTests(workspace: string, testParameters: TestRun
             it("Android RN app Debug test", async function () {
                 this.timeout(debugAndroidTestTime);
                 app = await vscodeManager.runVSCode(workspace, "Android RN app Debug test");
-                await app.workbench.quickaccess.openFile(appFileName);
+                await app.workbench.quickaccess.openFile(APP_FILE_NAME);
                 await sleep(1);
                 await app.workbench.editors.scrollTop();
-                SmokeTestLogger.info(`Android Debug test: ${appFileName} file is opened`);
+                SmokeTestLogger.info(`Android Debug test: ${APP_FILE_NAME} file is opened`);
 
                 await sleep(1);
                 await app.workbench.debug.setBreakpointOnLine(RNSetBreakpointOnLine);
@@ -69,8 +69,8 @@ export function startReactNativeTests(workspace: string, testParameters: TestRun
                 SmokeTestLogger.info("Android Debug test: Debugging started");
 
                 await app.workbench.debug.waitForStackFrame(
-                    sf => sf.name === appFileName && sf.lineNumber === RNSetBreakpointOnLine,
-                    `looking for ${appFileName} and line ${RNSetBreakpointOnLine}`,
+                    sf => sf.name === APP_FILE_NAME && sf.lineNumber === RNSetBreakpointOnLine,
+                    `looking for ${APP_FILE_NAME} and line ${RNSetBreakpointOnLine}`,
                 );
                 SmokeTestLogger.info("Android Debug test: Stack frame found");
                 await app.workbench.debug.stepOver();
@@ -112,9 +112,9 @@ export function startReactNativeTests(workspace: string, testParameters: TestRun
                 const launchConfigurationManager = new LaunchConfigurationManager(workspace);
                 const deviceName = iosSimulatorManager.getSimulator().name;
                 app = await vscodeManager.runVSCode(workspace, "iOS RN app Debug test");
-                await app.workbench.quickaccess.openFile(appFileName);
+                await app.workbench.quickaccess.openFile(APP_FILE_NAME);
                 await app.workbench.editors.scrollTop();
-                SmokeTestLogger.info(`iOS Debug test: ${appFileName} file is opened`);
+                SmokeTestLogger.info(`iOS Debug test: ${APP_FILE_NAME} file is opened`);
                 await app.workbench.debug.setBreakpointOnLine(RNSetBreakpointOnLine);
                 SmokeTestLogger.info(
                     `iOS Debug test: Breakpoint is set on line ${RNSetBreakpointOnLine}`,
@@ -132,8 +132,8 @@ export function startReactNativeTests(workspace: string, testParameters: TestRun
                 await app.workbench.debug.waitForDebuggingToStart();
                 SmokeTestLogger.info("iOS Debug test: Debugging started");
                 await app.workbench.debug.waitForStackFrame(
-                    sf => sf.name === appFileName && sf.lineNumber === RNSetBreakpointOnLine,
-                    `looking for ${appFileName} and line ${RNSetBreakpointOnLine}`,
+                    sf => sf.name === APP_FILE_NAME && sf.lineNumber === RNSetBreakpointOnLine,
+                    `looking for ${APP_FILE_NAME} and line ${RNSetBreakpointOnLine}`,
                 );
                 SmokeTestLogger.info("iOS Debug test: Stack frame found");
                 await app.workbench.debug.stepOver();

--- a/test/smoke/package/src/nativeDebug.test.ts
+++ b/test/smoke/package/src/nativeDebug.test.ts
@@ -71,40 +71,56 @@ export function startReactNativeTests(workspace: string, testParameters: TestRun
                 await sleep(1);
                 SmokeTestLogger.info("Android Debug test: Debugging started");
 
-                function waitForStackFrameFunc(maxExecutionTime) {
-                    return new Promise(resolve => {
-                        app.workbench.debug
-                            .waitForStackFrame(
-                                sf =>
-                                    sf.name === APP_FILE_NAME &&
-                                    sf.lineNumber === RNSetBreakpointOnLine,
-                                `looking for ${APP_FILE_NAME} and line ${RNSetBreakpointOnLine}`,
-                            )
-                            .then(() => resolve(true));
-                        setTimeout(() => resolve(false), maxExecutionTime);
-                    });
+                // function waitForStackFrameFunc(maxExecutionTime) {
+                //     return new Promise(resolve => {
+                //         app.workbench.debug
+                //             .waitForStackFrame(
+                //                 sf =>
+                //                     sf.name === APP_FILE_NAME &&
+                //                     sf.lineNumber === RNSetBreakpointOnLine,
+                //                 `looking for ${APP_FILE_NAME} and line ${RNSetBreakpointOnLine}`,
+                //             )
+                //             .then(() => resolve(true));
+                //         setTimeout(() => resolve(false), maxExecutionTime);
+                //     });
+                // }
+
+                // async function retryFunc(maxExecutionTime) {
+                //     let exced = await waitForStackFrameFunc(maxExecutionTime);
+                //     if (exced) {
+                //         // Doesn't exced max time
+                //     } else {
+                //         // Exced max time
+                //         SmokeTestLogger.info("Reloading React Native app...");
+                //         await app.workbench.quickinput.inputAndSelect("React Native: Reload App");
+
+                //         await app.workbench.debug.waitForStackFrame(
+                //             sf =>
+                //                 sf.name === APP_FILE_NAME &&
+                //                 sf.lineNumber === RNSetBreakpointOnLine,
+                //             `looking for ${APP_FILE_NAME} and line ${RNSetBreakpointOnLine}`,
+                //         );
+                //     }
+                // }
+
+                // const maxExecutionTime = 150_000;
+                // retryFunc(maxExecutionTime);
+
+                try {
+                    await app.workbench.debug.waitForStackFrame(
+                        sf => sf.name === APP_FILE_NAME && sf.lineNumber === RNSetBreakpointOnLine,
+                        `looking for ${APP_FILE_NAME} and line ${RNSetBreakpointOnLine}`,
+                    );
+                } catch (error) {
+                    SmokeTestLogger.error(`Error: ${error}`);
+                    SmokeTestLogger.info("Reloading React Native app...");
+                    await app.workbench.quickinput.inputAndSelect("React Native: Reload App");
+
+                    await app.workbench.debug.waitForStackFrame(
+                        sf => sf.name === APP_FILE_NAME && sf.lineNumber === RNSetBreakpointOnLine,
+                        `looking for ${APP_FILE_NAME} and line ${RNSetBreakpointOnLine}`,
+                    );
                 }
-
-                async function retryFunc(maxExecutionTime) {
-                    let exced = await waitForStackFrameFunc(maxExecutionTime);
-                    if (exced) {
-                        // Doesn't exced max time
-                    } else {
-                        // Exced max time
-                        SmokeTestLogger.info("Reloading React Native app...");
-                        await app.workbench.quickinput.inputAndSelect("React Native: Reload App");
-
-                        await app.workbench.debug.waitForStackFrame(
-                            sf =>
-                                sf.name === APP_FILE_NAME &&
-                                sf.lineNumber === RNSetBreakpointOnLine,
-                            `looking for ${APP_FILE_NAME} and line ${RNSetBreakpointOnLine}`,
-                        );
-                    }
-                }
-
-                const maxExecutionTime = 150_000;
-                retryFunc(maxExecutionTime);
 
                 await sleep(1);
                 SmokeTestLogger.info("Android Debug test: Stack frame found");

--- a/test/smoke/package/src/nativeDebug.test.ts
+++ b/test/smoke/package/src/nativeDebug.test.ts
@@ -45,20 +45,28 @@ export function startReactNativeTests(workspace: string, testParameters: TestRun
                 this.timeout(debugAndroidTestTime);
                 app = await vscodeManager.runVSCode(workspace, "Android RN app Debug test");
                 await app.workbench.quickaccess.openFile("App.js");
+                await sleep(1);
                 await app.workbench.editors.scrollTop();
                 SmokeTestLogger.info("Android Debug test: App.js file is opened");
+
+                await sleep(1);
                 await app.workbench.debug.setBreakpointOnLine(RNSetBreakpointOnLine);
                 SmokeTestLogger.info(
                     `Android Debug test: Breakpoint is set on line ${RNSetBreakpointOnLine}`,
                 );
+
                 SmokeTestLogger.info(
                     `Android Debug test: Chosen debug configuration: ${AndroidRNDebugConfigName}`,
                 );
                 SmokeTestLogger.info("Android Debug test: Starting debugging");
                 await app.workbench.quickaccess.runDebugScenario(AndroidRNDebugConfigName);
+                await sleep(1);
+
                 await androidEmulatorManager.waitUntilAppIsInstalled(RN_APP_PACKAGE_NAME);
+                await sleep(1);
                 await app.workbench.debug.waitForDebuggingToStart();
                 SmokeTestLogger.info("Android Debug test: Debugging started");
+
                 await app.workbench.debug.waitForStackFrame(
                     sf => sf.name === "App.js" && sf.lineNumber === RNSetBreakpointOnLine,
                     `looking for App.js and line ${RNSetBreakpointOnLine}`,
@@ -73,6 +81,7 @@ export function startReactNativeTests(workspace: string, testParameters: TestRun
                 let found = await app.workbench.debug.waitForOutput(output =>
                     output.some(line => line.indexOf("Test output from debuggee") >= 0),
                 );
+
                 assert.notStrictEqual(
                     found,
                     false,

--- a/test/smoke/package/src/nativeDebug.test.ts
+++ b/test/smoke/package/src/nativeDebug.test.ts
@@ -113,7 +113,7 @@ export function startReactNativeTests(workspace: string, testParameters: TestRun
                 });
 
                 let p2 = app.workbench.debug.waitForStackFrame(
-                    sf => sf.name === APP_FILE_NAME && sf.lineNumber === RNSetBreakpointOnLine,
+                    sf => sf.name === "Test.js" && sf.lineNumber === RNSetBreakpointOnLine,
                     `looking for ${APP_FILE_NAME} and line ${RNSetBreakpointOnLine}`,
                 );
 

--- a/test/smoke/package/src/nativeDebug.test.ts
+++ b/test/smoke/package/src/nativeDebug.test.ts
@@ -73,16 +73,20 @@ export function startReactNativeTests(workspace: string, testParameters: TestRun
 
                 function waitForStackFrameFunc(maxExecutionTime) {
                     return new Promise(resolve => {
-                        app.workbench.debug.waitForStackFrame(
-                            sf => sf.name === APP_FILE_NAME && sf.lineNumber === RNSetBreakpointOnLine,
-                            `looking for ${APP_FILE_NAME} and line ${RNSetBreakpointOnLine}`,
-                        ).then(() => resolve(true));
+                        app.workbench.debug
+                            .waitForStackFrame(
+                                sf =>
+                                    sf.name === APP_FILE_NAME &&
+                                    sf.lineNumber === RNSetBreakpointOnLine,
+                                `looking for ${APP_FILE_NAME} and line ${RNSetBreakpointOnLine}`,
+                            )
+                            .then(() => resolve(true));
                         setTimeout(() => resolve(false), maxExecutionTime);
                     });
                 }
 
                 async function retryFunc(maxExecutionTime) {
-                    var exced = await waitForStackFrameFunc(maxExecutionTime);
+                    let exced = await waitForStackFrameFunc(maxExecutionTime);
                     if (exced) {
                         // Doesn't exced max time
                     } else {
@@ -90,7 +94,9 @@ export function startReactNativeTests(workspace: string, testParameters: TestRun
                         await app.workbench.quickinput.inputAndSelect("React Native: Reload App");
 
                         await app.workbench.debug.waitForStackFrame(
-                            sf => sf.name === APP_FILE_NAME && sf.lineNumber === RNSetBreakpointOnLine,
+                            sf =>
+                                sf.name === APP_FILE_NAME &&
+                                sf.lineNumber === RNSetBreakpointOnLine,
                             `looking for ${APP_FILE_NAME} and line ${RNSetBreakpointOnLine}`,
                         );
                     }

--- a/test/smoke/package/src/nativeDebug.test.ts
+++ b/test/smoke/package/src/nativeDebug.test.ts
@@ -16,6 +16,7 @@ const AndroidRNDebugConfigName = "Debug Android";
 const RnAppBundleId = "org.reactjs.native.example.latestRNApp";
 const IosRNDebugConfigName = "Debug classic iOS";
 
+const appFileName = "App.js";
 const RNSetBreakpointOnLine = 1;
 
 // Time for Android Debug Test before it reaches timeout
@@ -44,10 +45,10 @@ export function startReactNativeTests(workspace: string, testParameters: TestRun
             it("Android RN app Debug test", async function () {
                 this.timeout(debugAndroidTestTime);
                 app = await vscodeManager.runVSCode(workspace, "Android RN app Debug test");
-                await app.workbench.quickaccess.openFile("App.js");
+                await app.workbench.quickaccess.openFile(appFileName);
                 await sleep(1);
                 await app.workbench.editors.scrollTop();
-                SmokeTestLogger.info("Android Debug test: App.js file is opened");
+                SmokeTestLogger.info(`Android Debug test: ${appFileName} file is opened`);
 
                 await sleep(1);
                 await app.workbench.debug.setBreakpointOnLine(RNSetBreakpointOnLine);
@@ -68,8 +69,8 @@ export function startReactNativeTests(workspace: string, testParameters: TestRun
                 SmokeTestLogger.info("Android Debug test: Debugging started");
 
                 await app.workbench.debug.waitForStackFrame(
-                    sf => sf.name === "App.js" && sf.lineNumber === RNSetBreakpointOnLine,
-                    `looking for App.js and line ${RNSetBreakpointOnLine}`,
+                    sf => sf.name === appFileName && sf.lineNumber === RNSetBreakpointOnLine,
+                    `looking for ${appFileName} and line ${RNSetBreakpointOnLine}`,
                 );
                 SmokeTestLogger.info("Android Debug test: Stack frame found");
                 await app.workbench.debug.stepOver();
@@ -111,9 +112,9 @@ export function startReactNativeTests(workspace: string, testParameters: TestRun
                 const launchConfigurationManager = new LaunchConfigurationManager(workspace);
                 const deviceName = iosSimulatorManager.getSimulator().name;
                 app = await vscodeManager.runVSCode(workspace, "iOS RN app Debug test");
-                await app.workbench.quickaccess.openFile("App.js");
+                await app.workbench.quickaccess.openFile(appFileName);
                 await app.workbench.editors.scrollTop();
-                SmokeTestLogger.info("iOS Debug test: App.js file is opened");
+                SmokeTestLogger.info(`iOS Debug test: ${appFileName} file is opened`);
                 await app.workbench.debug.setBreakpointOnLine(RNSetBreakpointOnLine);
                 SmokeTestLogger.info(
                     `iOS Debug test: Breakpoint is set on line ${RNSetBreakpointOnLine}`,
@@ -131,8 +132,8 @@ export function startReactNativeTests(workspace: string, testParameters: TestRun
                 await app.workbench.debug.waitForDebuggingToStart();
                 SmokeTestLogger.info("iOS Debug test: Debugging started");
                 await app.workbench.debug.waitForStackFrame(
-                    sf => sf.name === "App.js" && sf.lineNumber === RNSetBreakpointOnLine,
-                    `looking for App.js and line ${RNSetBreakpointOnLine}`,
+                    sf => sf.name === appFileName && sf.lineNumber === RNSetBreakpointOnLine,
+                    `looking for ${appFileName} and line ${RNSetBreakpointOnLine}`,
                 );
                 SmokeTestLogger.info("iOS Debug test: Stack frame found");
                 await app.workbench.debug.stepOver();

--- a/test/smoke/package/src/nativeDebug.test.ts
+++ b/test/smoke/package/src/nativeDebug.test.ts
@@ -118,7 +118,7 @@ export function startReactNativeTests(workspace: string, testParameters: TestRun
                 });
 
                 let p2 = app.workbench.debug.waitForStackFrame(
-                    sf => sf.name === "Test.js" && sf.lineNumber === RNSetBreakpointOnLine,
+                    sf => sf.name === APP_FILE_NAME && sf.lineNumber === RNSetBreakpointOnLine,
                     `looking for ${APP_FILE_NAME} and line ${RNSetBreakpointOnLine}`,
                 );
 

--- a/test/smoke/package/src/nativeDebug.test.ts
+++ b/test/smoke/package/src/nativeDebug.test.ts
@@ -48,10 +48,12 @@ export function startReactNativeTests(workspace: string, testParameters: TestRun
                 await app.workbench.quickaccess.openFile(APP_FILE_NAME);
                 await sleep(1);
                 await app.workbench.editors.scrollTop();
+                await sleep(1);
                 SmokeTestLogger.info(`Android Debug test: ${APP_FILE_NAME} file is opened`);
 
                 await sleep(1);
                 await app.workbench.debug.setBreakpointOnLine(RNSetBreakpointOnLine);
+                await sleep(1);
                 SmokeTestLogger.info(
                     `Android Debug test: Breakpoint is set on line ${RNSetBreakpointOnLine}`,
                 );
@@ -66,12 +68,14 @@ export function startReactNativeTests(workspace: string, testParameters: TestRun
                 await androidEmulatorManager.waitUntilAppIsInstalled(RN_APP_PACKAGE_NAME);
                 await sleep(1);
                 await app.workbench.debug.waitForDebuggingToStart();
+                await sleep(1);
                 SmokeTestLogger.info("Android Debug test: Debugging started");
 
                 await app.workbench.debug.waitForStackFrame(
                     sf => sf.name === APP_FILE_NAME && sf.lineNumber === RNSetBreakpointOnLine,
                     `looking for ${APP_FILE_NAME} and line ${RNSetBreakpointOnLine}`,
                 );
+                await sleep(1);
                 SmokeTestLogger.info("Android Debug test: Stack frame found");
                 await app.workbench.debug.stepOver();
                 // await for our debug string renders in debug console

--- a/test/smoke/package/src/nativeDebug.test.ts
+++ b/test/smoke/package/src/nativeDebug.test.ts
@@ -43,11 +43,16 @@ export function startReactNativeTests(workspace: string, testParameters: TestRun
         // Android debug tests
         if (testParameters.RunAndroidTests || testParameters.RunBasicTests) {
             it("Android RN app Debug test", async function () {
+                SmokeTestLogger.info(`Android Debug test: Starting testing`);
                 this.timeout(debugAndroidTestTime);
+                SmokeTestLogger.info(`Android Debug test: Timeout is over`);
                 app = await vscodeManager.runVSCode(workspace, "Android RN app Debug test");
+                SmokeTestLogger.info(`Android Debug test: VS code is running`);
                 await app.workbench.quickaccess.openFile(APP_FILE_NAME);
+                SmokeTestLogger.info(`Android Debug test: ${APP_FILE_NAME} is opened`);
                 await sleep(1);
                 await app.workbench.editors.scrollTop();
+                SmokeTestLogger.info(`Android Debug test: Scrolled to the top`);
                 await sleep(1);
                 SmokeTestLogger.info(`Android Debug test: ${APP_FILE_NAME} file is opened`);
 

--- a/test/smoke/package/src/nativeDebug.test.ts
+++ b/test/smoke/package/src/nativeDebug.test.ts
@@ -48,7 +48,7 @@ export function startReactNativeTests(workspace: string, testParameters: TestRun
                 SmokeTestLogger.info(`Android Debug test: Timeout is over`);
                 app = await vscodeManager.runVSCode(workspace, "Android RN app Debug test");
                 SmokeTestLogger.info(`Android Debug test: VS code is running`);
-                await retryAsyncFunction(app.workbench.quickaccess.openFile(APP_FILE_NAME));
+                await retryAsyncFunction(() => app.workbench.quickaccess.openFile(APP_FILE_NAME));
                 SmokeTestLogger.info(`Android Debug test: ${APP_FILE_NAME} is opened`);
                 await sleep(1);
                 await app.workbench.editors.scrollTop();
@@ -76,7 +76,7 @@ export function startReactNativeTests(workspace: string, testParameters: TestRun
                 await sleep(1);
                 SmokeTestLogger.info("Android Debug test: Debugging started");
 
-                await retryAsyncFunction(
+                await retryAsyncFunction(() =>
                     app.workbench.debug.waitForStackFrame(
                         sf => sf.name === APP_FILE_NAME && sf.lineNumber === RNSetBreakpointOnLine,
                         `looking for ${APP_FILE_NAME} and line ${RNSetBreakpointOnLine}`,

--- a/test/smoke/package/src/nativeDebug.test.ts
+++ b/test/smoke/package/src/nativeDebug.test.ts
@@ -91,6 +91,7 @@ export function startReactNativeTests(workspace: string, testParameters: TestRun
                         // Doesn't exced max time
                     } else {
                         // Exced max time
+                        SmokeTestLogger.info("Reloading React Native app...");
                         await app.workbench.quickinput.inputAndSelect("React Native: Reload App");
 
                         await app.workbench.debug.waitForStackFrame(


### PR DESCRIPTION
Added waiting for elements rendering in the UI smoke tests. It's added because the interaction with DOM-tree elements sometimes starts before the element reaches the DOM-tree.