### PR TITLE
Add support for sourceMapRenames config option

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,6 +213,11 @@
                 "type": "object",
                 "description": "%reactNative.attach.sourceMapsPathOverrides.description%"
               },
+              "sourceMapRenames": {
+                "type": "boolean",
+                "description": "%reactNative.attach.sourceMapRenames.description%",
+                "default": false
+              },
               "trace": {
                 "type": "string",
                 "enum": [

--- a/package.json
+++ b/package.json
@@ -316,6 +316,11 @@
                 "type": "object",
                 "description": "%reactNative.launch.sourceMapsPathOverrides.description%"
               },
+              "sourceMapRenames": {
+                "type": "boolean",
+                "description": "%reactNative.attach.sourceMapRenames.description%",
+                "default": false
+              },
               "logCatArguments": {
                 "type": "array",
                 "description": "%reactNative.launch.logCatArguments.description%",
@@ -438,6 +443,11 @@
                 "type": "object",
                 "description": "%reactNative.attach.sourceMapsPathOverrides.description%"
               },
+              "sourceMapRenames": {
+                "type": "boolean",
+                "description": "%reactNative.attach.sourceMapRenames.description%",
+                "default": false
+              },
               "platform": {
                 "type": "string",
                 "enum": [
@@ -553,6 +563,11 @@
               "sourceMapPathOverrides": {
                 "type": "object",
                 "description": "%reactNative.launch.sourceMapsPathOverrides.description%"
+              },
+              "sourceMapRenames": {
+                "type": "boolean",
+                "description": "%reactNative.attach.sourceMapRenames.description%",
+                "default": false
               },
               "logCatArguments": {
                 "type": "array",

--- a/package.nls.json
+++ b/package.nls.json
@@ -39,6 +39,7 @@
   "reactNative.attach.cwd.description": "The path to the project root folder",
   "reactNative.attach.sourceMaps.description": "Whether to use JavaScript source maps to map the generated bundled code back to its original sources",
   "reactNative.attach.sourceMapsPathOverrides.description": "A set of mappings for rewriting the locations of source files from what the source map says, to their locations on disk. See https://github.com/microsoft/vscode-react-native#typescript-and-haul for details",
+  "reactNative.attach.sourceMapRenames.description": "Support for renamed identifiers in sourcemaps.",
   "reactNative.attach.trace.description": "Logging level in debugger process. May be useful for diagnostics. If set to \"Trace\" all debugger process logs will be available in 'Debug Console' output window.",
   "reactNative.attach.address.description": "TCP/IP address of packager to attach to for debugging. Default is 'localhost'.",
   "reactNative.attach.port.description": "Port of packager to attach to for debugging. Default is 8081.",

--- a/src/debugger/debugSessionBase.ts
+++ b/src/debugger/debugSessionBase.ts
@@ -143,7 +143,7 @@ export abstract class DebugSessionBase extends LoggingDebugSession {
                 args.enableDebug = true;
             }
 
-            // Now there is problem with processing time of 'createFromSourceMap' function of js-debug
+            // Now there is a problem with processing time of 'createFromSourceMap' function of js-debug
             // So we disable this functionality by default https://github.com/microsoft/vscode-js-debug/issues/1033
             if (typeof args.sourceMapRenames !== "boolean") {
                 args.sourceMapRenames = false;

--- a/src/debugger/debugSessionBase.ts
+++ b/src/debugger/debugSessionBase.ts
@@ -143,6 +143,12 @@ export abstract class DebugSessionBase extends LoggingDebugSession {
                 args.enableDebug = true;
             }
 
+            // Now there is problem with processing time of 'createFromSourceMap' function of js-debug
+            // So we disable this functionality by default https://github.com/microsoft/vscode-js-debug/issues/1033
+            if (typeof args.sourceMapRenames !== "boolean") {
+                args.sourceMapRenames = false;
+            }
+
             const projectRootPath = getProjectRoot(args);
 
             return ReactNativeProjectHelper.isReactNativeProject(projectRootPath).then(

--- a/src/debugger/jsDebugConfigAdapter.ts
+++ b/src/debugger/jsDebugConfigAdapter.ts
@@ -53,18 +53,13 @@ export class JsDebugConfigAdapter {
             existingExtraArgs.envFile = attachArgs.envFile;
         }
         existingExtraArgs.sourceMaps = attachArgs.sourceMaps;
+        existingExtraArgs.sourceMapRenames = attachArgs.sourceMapRenames;
         if (attachArgs.sourceMapPathOverrides) {
             existingExtraArgs.sourceMapPathOverrides = attachArgs.sourceMapPathOverrides;
         }
         if (attachArgs.skipFiles) {
             existingExtraArgs.skipFiles = attachArgs.skipFiles;
         }
-
-        // There is problem with processing time of 'createFromSourceMap' function of js-debug
-        // So we disable this functionality by default https://github.com/microsoft/vscode-js-debug/issues/1033
-        existingExtraArgs.sourceMapRenames = attachArgs.sourceMapRenames
-            ? attachArgs.sourceMapRenames
-            : false;
 
         return existingExtraArgs;
     }

--- a/src/debugger/jsDebugConfigAdapter.ts
+++ b/src/debugger/jsDebugConfigAdapter.ts
@@ -60,6 +60,12 @@ export class JsDebugConfigAdapter {
             existingExtraArgs.skipFiles = attachArgs.skipFiles;
         }
 
+        // There is problem with processing time of 'createFromSourceMap' function of js-debug
+        // So we disable this functionality by default https://github.com/microsoft/vscode-js-debug/issues/1033
+        existingExtraArgs.sourceMapRenames = attachArgs.sourceMapRenames
+            ? attachArgs.sourceMapRenames
+            : false;
+
         return existingExtraArgs;
     }
 }


### PR DESCRIPTION
Now there is problem with processing time of 'createFromSourceMap' function of js-debug. So we disable `sourceMapRenames` option by default.