### PR TITLE
fix(attach): respect env, envFile from IAttachRequestArgs

### DIFF
--- a/package.json
+++ b/package.json
@@ -262,6 +262,19 @@
                 "type": "string",
                 "description": "%reactNative.attach.debuggerWorkerUrlPath.description%",
                 "default": "debugger-ui/"
+              },
+              "env": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "%reactNative.launch.env.description%",
+                "default": {}
+              },
+              "envFile": {
+                "type": "string",
+                "description": "%reactNative.launch.envFile.description%",
+                "default": "${workspaceFolder}/.env"
               }
             }
           },
@@ -497,6 +510,19 @@
                   "type": "string"
                 },
                 "default": []
+              },
+              "env": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "%reactNative.launch.env.description%",
+                "default": {}
+              },
+              "envFile": {
+                "type": "string",
+                "description": "%reactNative.launch.envFile.description%",
+                "default": "${workspaceFolder}/.env"
               }
             }
           },

--- a/src/debugger/direct/directDebugSession.ts
+++ b/src/debugger/direct/directDebugSession.ts
@@ -135,6 +135,7 @@ export class DirectDebugSession extends DebugSessionBase {
                 versions,
                 extProps,
             );
+            this.appLauncher.getPackager().setRunOptions(attachArgs);
 
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             await TelemetryHelper.generate("attach", extProps, async generator => {

--- a/src/debugger/rnDebugSession.ts
+++ b/src/debugger/rnDebugSession.ts
@@ -116,6 +116,7 @@ export class RNDebugSession extends DebugSessionBase {
                     versions,
                     extProps,
                 );
+                this.appLauncher.getPackager().setRunOptions(attachArgs);
 
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 await TelemetryHelper.generate("attach", extProps, async generator => {


### PR DESCRIPTION
if `env` or `envFile` are specified as args for attach tasks they
should be respected. otherwise, the only way to set environment
variables when attaching is via a `.env` file. this is particularly
misleading because the documentation (and definition of
`IAttachRequestArgs`) imply that it should work.

currently the `runOptions` were never getting set when responding
to attach requests, resulting in the `env` and `envFile` check in
`Packager#start()` skipping the env update.

call `setRunOptions(attachArgs)` in `attachRequest` after
`appLauncher` and `appLauncher.packager` are initialized via the
call to `initializeSettings` to ensure `runOptions` is valid and
`env` or `envFile` can be correctly read.