### PR TITLE
fix(debug): respect port option when starting packager

### DIFF
--- a/src/common/packager.ts
+++ b/src/common/packager.ts
@@ -85,6 +85,10 @@ export class Packager {
         return this.packagerPort || SettingsHelper.getPackagerPort(this.workspacePath);
     }
 
+    public setPort(packagerPort: number): void {
+        this.packagerPort = packagerPort;
+    }
+
     public setRunOptions(runOptions: IRunOptions): void {
         this.runOptions = runOptions;
     }

--- a/src/debugger/direct/directDebugSession.ts
+++ b/src/debugger/direct/directDebugSession.ts
@@ -150,6 +150,8 @@ export class DirectDebugSession extends DebugSessionBase {
                     );
                 }
                 attachArgs.port = port;
+                this.appLauncher.getPackager().setPort(attachArgs.port);
+
                 logger.log(`Connecting to ${attachArgs.port} port`);
                 await this.appLauncher.getRnCdpProxy().stopServer();
 

--- a/src/debugger/rnDebugSession.ts
+++ b/src/debugger/rnDebugSession.ts
@@ -122,6 +122,8 @@ export class RNDebugSession extends DebugSessionBase {
                     attachArgs.port =
                         attachArgs.port || this.appLauncher.getPackagerPort(attachArgs.cwd);
 
+                    this.appLauncher.getPackager().setPort(attachArgs.port);
+
                     const cdpProxy = this.appLauncher.getRnCdpProxy();
                     await cdpProxy.stopServer();
                     await cdpProxy.initializeServer(


### PR DESCRIPTION
currently if a `port` is specified in attach options, the specified
port is not passed to the packager invocation, resulting in the
packager launching on the default 8081 port and the debugger not
connecting to it as it uses the custom port.

set `Packager.packagerPort` explicitly based on the specified port
or the setting derived from any custom specified `cwd`