### PR TITLE
Add WebSocket connection to packager & stop debugging when another debugger is connected

### DIFF
--- a/src/common/packager.ts
+++ b/src/common/packager.ts
@@ -24,6 +24,7 @@ import { findFileInFolderHierarchy } from "./extensionHelper";
 import { FileSystem } from "./node/fileSystem";
 import { PromiseUtil } from "./node/promise";
 import { CONTEXT_VARIABLES_NAMES } from "./contextVariablesNames";
+import * as WebSocket from "ws";
 
 nls.config({
     messageFormat: nls.MessageFormat.bundle,
@@ -40,6 +41,7 @@ export class Packager {
         OutputChannelLogger.MAIN_CHANNEL_NAME,
         true,
     );
+    private packagerSocket: WebSocket;
 
     // old name for RN < 0.60.0, new for versions >= 0.60.0
     private static JS_INJECTOR_FILENAME = {
@@ -342,6 +344,54 @@ export class Packager {
         } catch (error) {
             return false;
         }
+    }
+
+    public async forMessage(
+        message: string,
+        arg: { level: string; type: string; mode: string },
+    ): Promise<void> {
+        await this.awaitStart();
+
+        if (!this.packagerSocket || this.packagerSocket.CLOSED || this.packagerSocket.CLOSING) {
+            const wsUrl = `ws://${this.getHost()}/events`;
+            this.packagerSocket = new WebSocket(wsUrl, {
+                origin: "http://localhost:8081/debugger-ui", // random url because of packager bug
+            });
+        }
+
+        return new Promise<void>((resolve, reject) => {
+            const resolveHandler = async (handlerArg: string) => {
+                const parsed: {
+                    data: any;
+                    type: string;
+                    level: string;
+                    mode: string;
+                } = JSON.parse(handlerArg);
+
+                const value = parsed.data?.[0];
+
+                if (
+                    arg.level !== parsed.level ||
+                    arg.type !== parsed.type ||
+                    arg.mode !== parsed.mode ||
+                    !value ||
+                    typeof value !== "string"
+                ) {
+                    return;
+                }
+
+                if (value.includes(message)) {
+                    resolve();
+                    this.packagerSocket.removeListener("message", resolveHandler);
+                    this.packagerSocket.removeListener("error", reject);
+                    this.packagerSocket.removeListener("close", reject);
+                }
+            };
+
+            this.packagerSocket.addListener("error", reject);
+            this.packagerSocket.addListener("close", reject);
+            this.packagerSocket.addListener("message", resolveHandler);
+        });
     }
 
     private async awaitStart(retryCount = 60, delay = 3000): Promise<void> {

--- a/src/common/packager.ts
+++ b/src/common/packager.ts
@@ -3,9 +3,11 @@
 
 import { ChildProcess } from "child_process";
 import * as path from "path";
+import * as assert from "assert";
 import * as semver from "semver";
 import * as vscode from "vscode";
 import * as nls from "vscode-nls";
+import * as WebSocket from "ws";
 import { GeneralPlatform } from "../extension/generalPlatform";
 import { ExponentHelper } from "../extension/exponent/exponentHelper";
 import { OutputChannelLogger } from "../extension/log/OutputChannelLogger";
@@ -24,8 +26,6 @@ import { findFileInFolderHierarchy } from "./extensionHelper";
 import { FileSystem } from "./node/fileSystem";
 import { PromiseUtil } from "./node/promise";
 import { CONTEXT_VARIABLES_NAMES } from "./contextVariablesNames";
-import * as WebSocket from "ws";
-import * as assert from "assert";
 
 nls.config({
     messageFormat: nls.MessageFormat.bundle,
@@ -81,7 +81,7 @@ export class Packager {
             packagerStatusIndicator || new PackagerStatusIndicator(projectPath);
     }
 
-    closeWsConnection(): void {
+    public closeWsConnection(): void {
         this.packagerSocket?.close();
     }
 

--- a/src/debugger/direct/directDebugSession.ts
+++ b/src/debugger/direct/directDebugSession.ts
@@ -125,24 +125,28 @@ export class DirectDebugSession extends DebugSessionBase {
         try {
             await this.initializeSettings(attachArgs);
 
-            void this.appLauncher
-                .getPackager()
-                .forMessage("Already connected:", {
+            const packager = this.appLauncher.getPackager();
+            const args: Parameters<typeof packager.forMessage> = [
+                // message indicates that another debugger has connected
+                "Already connected:",
+                {
                     type: "client_log",
                     level: "warn",
                     mode: "BRIDGE",
-                })
-                .then(
-                    () => {
-                        this.showError(
-                            ErrorHelper.getInternalError(
-                                InternalErrorCode.AnotherDebuggerConnectedToPackager,
-                            ),
-                            response,
-                        );
-                    },
-                    () => {},
-                );
+                },
+            ];
+
+            void packager.forMessage(...args).then(
+                () => {
+                    this.showError(
+                        ErrorHelper.getInternalError(
+                            InternalErrorCode.AnotherDebuggerConnectedToPackager,
+                        ),
+                        response,
+                    );
+                },
+                () => {},
+            );
 
             logger.log("Attaching to the application");
             logger.verbose(`Attaching to the application: ${JSON.stringify(attachArgs, null, 2)}`);
@@ -237,8 +241,8 @@ export class DirectDebugSession extends DebugSessionBase {
     ): Promise<void> {
         this.iOSWKDebugProxyHelper.cleanUp();
         this.onDidTerminateDebugSessionHandler.dispose();
+        this.appLauncher.getPackager().closeWsConnection();
         void super.disconnectRequest(response, args, request);
-        this.appLauncher.getPackager().packagerSocket.close();
     }
 
     protected async establishDebugSession(attachArgs: IAttachRequestArgs): Promise<void> {


### PR DESCRIPTION
#1720 

Add connection to packager and listen for message indicating that another debugger has connected.

Only works on iOS because of Hermes bug https://github.com/facebook/react-native/issues/32904