### PR TITLE
Allow extension to work on canary builds of RN

### DIFF
--- a/src/extension/rn-extension.ts
+++ b/src/extension/rn-extension.ts
@@ -373,8 +373,14 @@ async function setupAndDispose<T extends ISetupableDisposable>(
     return setuptableDisposable;
 }
 
+// We should work with daily canary builds of react-native since those are also newer than 0.19,
+// and allow earlier testing of the extension on newer builds of react-native
+function isCanaryVersion(version: string): boolean {
+    return semver.major(version) === 0 && semver.minor(version) === 0;
+}
+
 function isSupportedVersion(version: string): boolean {
-    if (!!semver.valid(version) && !semver.gte(version, "0.19.0")) {
+    if (!!semver.valid(version) && !semver.gte(version, "0.19.0") && !isCanaryVersion(version)) {
         TelemetryHelper.sendSimpleEvent("unsupportedRNVersion", { rnVersion: version });
         const shortMessage = localize(
             "ReactNativeToolsRequiresMoreRecentVersionThan019",


### PR DESCRIPTION
Anyone trying to test the latest builds of react-native is unable to use this extension due to the version check.  Canary builds of react-native are published with a version `0.0.0-<date/commit tag>`

The extension should work with those versions.