### PR TITLE
fix findxcodeproject function location

### DIFF
--- a/src/extension/ios/plistBuddy.ts
+++ b/src/extension/ios/plistBuddy.ts
@@ -248,17 +248,16 @@ export class PlistBuddy {
          */
         const iOSCliFolderName =
             semver.gte(rnVersion, PlistBuddy.NEW_RN_IOS_CLI_LOCATION_VERSION) ||
-                ProjectVersionHelper.isCanaryVersion(rnVersion)
+            ProjectVersionHelper.isCanaryVersion(rnVersion)
                 ? "cli-platform-ios"
                 : "cli";
 
-        const findXcodeProjectLocation =
-            `node_modules/@react-native-community/${iOSCliFolderName}/build/${
-                semver.gte(rnVersion, PlistBuddy.RN69_FUND_XCODE_PROJECT_LOCATION_VERSION) ||
-                semver.gte(rnVersion, PlistBuddy.RN68_FUND_XCODE_PROJECT_LOCATION_VERSION)
+        const findXcodeProjectLocation = `node_modules/@react-native-community/${iOSCliFolderName}/build/${
+            semver.gte(rnVersion, PlistBuddy.RN69_FUND_XCODE_PROJECT_LOCATION_VERSION) ||
+            semver.gte(rnVersion, PlistBuddy.RN68_FUND_XCODE_PROJECT_LOCATION_VERSION)
                 ? "config/findXcodeProject"
                 : "commands/runIOS/findXcodeProject"
-            }`;
+        }`;
         const findXcodeProject = customRequire(
             path.join(
                 AppLauncher.getNodeModulesRootByProjectPath(projectRoot),

--- a/src/extension/ios/plistBuddy.ts
+++ b/src/extension/ios/plistBuddy.ts
@@ -248,15 +248,17 @@ export class PlistBuddy {
          */
         const iOSCliFolderName =
             semver.gte(rnVersion, PlistBuddy.NEW_RN_IOS_CLI_LOCATION_VERSION) ||
-            ProjectVersionHelper.isCanaryVersion(rnVersion)
+                ProjectVersionHelper.isCanaryVersion(rnVersion)
                 ? "cli-platform-ios"
                 : "cli";
 
-        const findXcodeProjectLocation = `node_modules/@react-native-community/${iOSCliFolderName}/build/${
-            semver.gte(rnVersion, PlistBuddy.RN69_FUND_XCODE_PROJECT_LOCATION_VERSION) || semver.gte(rnVersion, PlistBuddy.RN68_FUND_XCODE_PROJECT_LOCATION_VERSION)
+        const findXcodeProjectLocation =
+            `node_modules/@react-native-community/${iOSCliFolderName}/build/${
+                semver.gte(rnVersion, PlistBuddy.RN69_FUND_XCODE_PROJECT_LOCATION_VERSION) ||
+                semver.gte(rnVersion, PlistBuddy.RN68_FUND_XCODE_PROJECT_LOCATION_VERSION)
                 ? "config/findXcodeProject"
                 : "commands/runIOS/findXcodeProject"
-        }`;
+            }`;
         const findXcodeProject = customRequire(
             path.join(
                 AppLauncher.getNodeModulesRootByProjectPath(projectRoot),

--- a/src/extension/ios/plistBuddy.ts
+++ b/src/extension/ios/plistBuddy.ts
@@ -27,6 +27,7 @@ export class PlistBuddy {
     private static readonly plistBuddyExecutable = "/usr/libexec/PlistBuddy";
     private static readonly SCHEME_IN_PRODUCTS_FOLDER_PATH_VERSION = "0.59.0";
     private static readonly NEW_RN_IOS_CLI_LOCATION_VERSION = "0.60.0";
+    private static readonly RN68_FUND_XCODE_PROJECT_LOCATION_VERSION = "0.68.0";
     private static readonly RN69_FUND_XCODE_PROJECT_LOCATION_VERSION = "0.69.0";
     private readonly TARGET_BUILD_DIR_SEARCH_KEY = "TARGET_BUILD_DIR";
     private readonly FULL_PRODUCT_NAME_SEARCH_KEY = "FULL_PRODUCT_NAME";
@@ -250,8 +251,9 @@ export class PlistBuddy {
             ProjectVersionHelper.isCanaryVersion(rnVersion)
                 ? "cli-platform-ios"
                 : "cli";
+
         const findXcodeProjectLocation = `node_modules/@react-native-community/${iOSCliFolderName}/build/${
-            semver.gte(rnVersion, PlistBuddy.RN69_FUND_XCODE_PROJECT_LOCATION_VERSION)
+            semver.gte(rnVersion, PlistBuddy.RN69_FUND_XCODE_PROJECT_LOCATION_VERSION) || semver.gte(rnVersion, PlistBuddy.RN68_FUND_XCODE_PROJECT_LOCATION_VERSION)
                 ? "config/findXcodeProject"
                 : "commands/runIOS/findXcodeProject"
         }`;


### PR DESCRIPTION
Fix issue https://github.com/microsoft/vscode-react-native/issues/1781: [Bug] Command 'React Native: Run iOS on Simulator' resulted in an error (Cannot find module '[edited]/node_modules/@react-native-community/cli-platform-ios/build/commands/runIOS/findXcodeProject'.

** Test Plan **
```
gulp release
rf ~/.vscode/extensions/msjsdiag.vscode-react-native-1.9.3
code --install-extension vscode-react-native-1.9.3.vsix
```
Is working now with React Native 0.68.2. I can run the debugger and connect successfully 