### PR TITLE
Fix deprecated new Buffer() to Buffer.from

### DIFF
--- a/src/common/telemetry.ts
+++ b/src/common/telemetry.ts
@@ -104,7 +104,7 @@ export module Telemetry {
         public setPiiProperty(name: string, value: string): void {
             let hmac: crypto.Hmac = crypto.createHmac(
                 "sha256",
-                new Buffer(TelemetryEvent.PII_HASH_KEY, "utf8"),
+                Buffer.from(TelemetryEvent.PII_HASH_KEY, "utf8"),
             );
             let hashedValue: string = hmac.update(value).digest("hex");
 

--- a/test/resources/processExecution/simulator.ts
+++ b/test/resources/processExecution/simulator.ts
@@ -160,14 +160,14 @@ export class Simulator {
                     const previousOutputLength = this.allStdout.length;
                     this.allStdout += data;
                     this.simulateOutputSideEffects(data, previousOutputLength).then(() => {
-                        this.process.stdout.emit("data", new Buffer(data));
+                        this.process.stdout.emit("data", Buffer.from(data));
                     });
                     break;
                 }
                 case "stderr": {
                     const data = (<IStdErrEvent>event).stderr.data;
                     this.allStderr += data;
-                    this.process.stderr.emit("data", new Buffer(data));
+                    this.process.stderr.emit("data", Buffer.from(data));
                     break;
                 }
                 case "error":


### PR DESCRIPTION
Fix #1904 