### PR TITLE
Fix VS Code CLI parameter duplication in extension installation

### DIFF
--- a/test/smoke/suites/activation.test.ts
+++ b/test/smoke/suites/activation.test.ts
@@ -42,7 +42,7 @@ export function startExtensionActivationTests(): void {
             try {
                 await ElementHelper.WaitElementSelectorVisible(
                     `[id="${Constant.previewExtensionId}"]`,
-                    2000,
+                    10000,
                 );
                 SmokeTestLogger.info("React-native preview extension is activated");
                 isActivited = true;
@@ -50,7 +50,7 @@ export function startExtensionActivationTests(): void {
                 try {
                     await ElementHelper.WaitElementSelectorVisible(
                         `[id="${Constant.prodExtensionId}"]`,
-                        2000,
+                        10000,
                     );
                     SmokeTestLogger.info("React-native prod extension is activated");
                     isActivited = true;

--- a/test/smoke/suites/helper/application.ts
+++ b/test/smoke/suites/helper/application.ts
@@ -54,7 +54,7 @@ export class Application {
             timeout: 10000,
         });
 
-        await utilities.sleep(5000);
+        await utilities.sleep(10000);
         return this.mainPage;
     }
 


### PR DESCRIPTION
When launching VS Code for a smoke test, the --extensions-dir argument was passed twice in the command line, and VS Code ultimately only used the latter value.