### PR TITLE
Fix security vulnerability: bump uuid from 9.0.0 to 14.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "source-map-resolve": "0.5.3",
         "strip-json-comments": "2.0.1",
         "tmp-promise": "3.0.2",
-        "uuid": "9.0.0",
+        "uuid": "^14.0.0",
         "vscode-cdp-proxy": "0.2.0",
         "vscode-extension-telemetry": "0.4.5",
         "vscode-nls": "4.1.2",
@@ -11937,11 +11937,16 @@
       "dev": true
     },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -22014,9 +22019,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -1457,7 +1457,7 @@
     "source-map-resolve": "0.5.3",
     "strip-json-comments": "2.0.1",
     "tmp-promise": "3.0.2",
-    "uuid": "9.0.0",
+    "uuid": "^14.0.0",
     "vscode-cdp-proxy": "0.2.0",
     "vscode-extension-telemetry": "0.4.5",
     "vscode-nls": "4.1.2",


### PR DESCRIPTION
## Summary

Upgrade `uuid` from `9.0.0` to `^14.0.0` to address CVE-2026-4800 (moderate severity).

Both usages in the codebase already use the modern `import { v4 } from 'uuid'` syntax, so no code changes are required.

## Files changed

- `package.json`
- `package-lock.json`

## Test plan

- [ ] Run `gulp build` — no errors
- [ ] Run `npm test` — no regressions

Closes #2606
