### PR TITLE
Disable the SDL security check phase in the CI pipeline

### DIFF
--- a/.ci/master-pipeline.yml
+++ b/.ci/master-pipeline.yml
@@ -14,6 +14,8 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    sdl:
+      enabled: false
     pool:
       name: VSWebDiag1ESPipelinePool
       image: VSWebDiag_1ESImage_Windows


### PR DESCRIPTION
In the CI pipeline configuration (.ci/master-pipeline.yml), disable SDL security development lifecycle checks to improve build efficiency or adapt to current project requirements. This change ensures that the pipeline does not enforce SDL-related tasks, making it suitable for scenarios where mandatory security compliance is not required.