### PR TITLE
Expand command palette smoke coverage

### DIFF
--- a/test/smoke/suites/commands.test.ts
+++ b/test/smoke/suites/commands.test.ts
@@ -39,6 +39,8 @@ export function startCommandPaletteTests(): void {
 
                 const value = await option.getAttribute("aria-label");
                 assert.ok(value?.includes(command), `Command '${command}' is not visible`);
+
+                await ComponentHelper.closeCommandPalette();
             }
         });
     });

--- a/test/smoke/suites/commands.test.ts
+++ b/test/smoke/suites/commands.test.ts
@@ -11,24 +11,35 @@ export function startCommandPaletteTests(): void {
     describe("CommandPaletteTest", () => {
         afterEach(BaseSmokeTest.dispose);
 
-        it("Verify react native command is visible in command palette", async () => {
-            const text = "React Native: Start Packager";
+        it("Verify react native commands are visible in command palette", async () => {
+            const expectedCommands = [
+                "React Native: Start Packager",
+                "React Native: Clean & Restart Packager (Metro)",
+                "React Native: Install CocoaPods dependencies",
+                "React Native: Run EAS Build",
+                "React Native: Expo - Run Doctor",
+                "React Native: Expo - Prebuild",
+                "React Native: Expo - Prebuild Clean",
+            ];
+
             await BaseSmokeTest.initApp();
 
-            await ComponentHelper.openCommandPalette();
-            await ElementHelper.WaitElementClassNameVisible(
-                Element.commandPaletteClassName,
-                TimeoutConstants.COMMAND_PALETTE_TIMEOUT,
-            );
+            for (const command of expectedCommands) {
+                await ComponentHelper.openCommandPalette();
+                await ElementHelper.WaitElementClassNameVisible(
+                    Element.commandPaletteClassName,
+                    TimeoutConstants.COMMAND_PALETTE_TIMEOUT,
+                );
 
-            await ElementHelper.inputText(text);
-            const option = await ElementHelper.WaitElementSelectorVisible(
-                Element.commandPaletteFocusedItemSelector,
-                TimeoutConstants.COMMAND_PALETTE_TIMEOUT,
-            );
+                await ElementHelper.inputText(command);
+                const option = await ElementHelper.WaitElementSelectorVisible(
+                    Element.commandPaletteFocusedItemSelector,
+                    TimeoutConstants.COMMAND_PALETTE_TIMEOUT,
+                );
 
-            const value = await option.getAttribute("aria-label");
-            assert.ok(value?.includes(text));
+                const value = await option.getAttribute("aria-label");
+                assert.ok(value?.includes(command), `Command '${command}' is not visible`);
+            }
         });
     });
 }

--- a/test/smoke/suites/helper/componentHelper.ts
+++ b/test/smoke/suites/helper/componentHelper.ts
@@ -17,6 +17,10 @@ export class ComponentHelper {
         await ElementHelper.sendKeys(`${cmdKey}+Shift+P`);
     }
 
+    public static async closeCommandPalette() {
+        await ElementHelper.sendKeys("Escape");
+    }
+
     public static async executeCommand(commandName: string) {
         await this.openCommandPalette();
         await ElementHelper.WaitElementClassNameVisible(

--- a/test/smoke/suites/networkInspector.test.ts
+++ b/test/smoke/suites/networkInspector.test.ts
@@ -35,6 +35,8 @@ export function startNetworkInspectorTests(): void {
 
                 const value = await option.getAttribute("aria-label");
                 assert.ok(value?.includes(command), `Command '${command}' is not visible`);
+
+                await ComponentHelper.closeCommandPalette();
             }
         });
     });


### PR DESCRIPTION
## Summary
Expand smoke coverage for React Native command palette entries added or refactored recently.

## Proposed Changes
- Check visibility for Start Packager, Clean & Restart Packager, CocoaPods install, EAS Build, and Expo command entries.
- Add a small command palette close helper to avoid search state leaking between checks.
- Reuse the close helper in the network inspector smoke coverage loop.

## Test Plan
- npm run build
- npm run compile-smoke-tests (blocked by existing adm-zip module resolution error in test/smoke/suites/vsixbuild.test.ts)

Closes #2641