### PR TITLE
Stabilize experiment service host tests

### DIFF
--- a/test/extension/experimentService/experimentService.test.ts
+++ b/test/extension/experimentService/experimentService.test.ts
@@ -1,27 +1,79 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
-import {
-    ExperimentService,
+import type {
+    ExperimentService as ExperimentServiceType,
     ExperimentConfig,
-    ExperimentStatuses,
     ExperimentResult,
 } from "../../../src/extension/services/experimentService/experimentService";
-import Configstore = require("configstore");
 import assert = require("assert");
+import proxyquire = require("proxyquire");
+
+const experimentServicePath = "../../../src/extension/services/experimentService/experimentService";
+
+class TestConfigstore {
+    private values: Record<string, unknown> = {};
+
+    public get<T>(key: string): T {
+        return this.clone(this.values[key]) as T;
+    }
+
+    public set(key: string, value: unknown): void {
+        this.values[key] = this.clone(value);
+    }
+
+    public delete(key: string): void {
+        delete this.values[key];
+    }
+
+    private clone(value: unknown): unknown {
+        return value === undefined ? undefined : JSON.parse(JSON.stringify(value));
+    }
+}
+
+const config = new TestConfigstore();
+
+type ExperimentServiceModule =
+    typeof import("../../../src/extension/services/experimentService/experimentService");
+
+const mockedExperimentsConfig: ExperimentConfig[] = [
+    {
+        experimentName: "RNTPreviewPrompt",
+        popCoveragePercent: 1,
+        enabled: true,
+    },
+];
+
+const experimentServiceModule = proxyquire(experimentServicePath, {
+    "../remoteConfigHelper": {
+        retryDownloadConfig: () => Promise.resolve(mockedExperimentsConfig),
+    },
+    "../../extensionConfigManager": {
+        ExtensionConfigManager: {
+            config,
+        },
+    },
+}) as ExperimentServiceModule;
+
+const { ExperimentService, ExperimentStatuses } = experimentServiceModule;
 
 suite("experimentService", function () {
-    const configName = "reactNativeToolsConfig";
     const testExperimentName = "testName";
-    const config = new Configstore(configName);
+    let experimentService: ExperimentServiceType | undefined;
 
-    teardown(() => {
+    function disposeExperimentService(): void {
+        if (experimentService) {
+            experimentService.dispose();
+            experimentService = undefined;
+        }
         (<any>ExperimentService).instance = null;
-    });
+    }
+
+    teardown(disposeExperimentService);
 
     suite("initializationAndExperimentConfig", function () {
         test("should return correct experiment config", async () => {
-            let experimentService = ExperimentService.create();
+            experimentService = ExperimentService.create();
             let downloadedExperimentsConfig: ExperimentConfig[] = await (<any>experimentService)
                 .downloadConfigRequest;
             let result = downloadedExperimentsConfig.every(
@@ -58,25 +110,26 @@ suite("experimentService", function () {
         }
 
         teardown(() => {
-            (<any>ExperimentService).instance = null;
             config.delete(testExperimentName);
             config.delete(RNTPreviewPromptExp.experimentName);
         });
 
         test("should skip the experiment", async () => {
             config.set(testExperimentName, expTestConfig);
-            let experimentService = <any>ExperimentService.create();
-            await configureExperimentService(experimentService, expTestConfig);
-            let experimentResult: ExperimentResult = await experimentService.executeExperiment(
-                expTestConfig,
-            );
+            experimentService = ExperimentService.create();
+            const service = <any>experimentService;
+            service.downloadedExperimentsConfig = [expTestConfig];
+            service.experimentsInstances = new Map();
+
+            let experimentResult: ExperimentResult = await service.executeExperiment(expTestConfig);
             assert.strictEqual(experimentResult.resultStatus, ExperimentStatuses.DISABLED);
         });
 
         test("should succeed the experiment", async () => {
-            let experimentService = <any>ExperimentService.create();
-            await configureExperimentService(experimentService, RNTPreviewPromptExp);
-            let experimentResult: ExperimentResult = await experimentService.executeExperiment(
+            experimentService = ExperimentService.create();
+            const service = <any>experimentService;
+            await configureExperimentService(service, RNTPreviewPromptExp);
+            let experimentResult: ExperimentResult = await service.executeExperiment(
                 RNTPreviewPromptExp,
             );
             assert.strictEqual(experimentResult.resultStatus, ExperimentStatuses.ENABLED);


### PR DESCRIPTION
## Summary
Stabilize the experiment service host tests that have timed out intermittently in CI.

## Proposed Changes
- Mock experiment remote config loading in `experimentService.test.ts`.
- Replace real configstore access with an in-memory test config store.
- Make the skipped experiment test deterministic by avoiding the dynamic import failure path for a nonexistent experiment.

## Test Plan
- npm run build
- npm test -- --verbose

Closes #2650