### PR TITLE
Harden iOS device ID validation and idb command execution

### DIFF
--- a/src/extension/ios/iOSContainerUtility.ts
+++ b/src/extension/ios/iOSContainerUtility.ts
@@ -182,9 +182,18 @@ async function push(
     await checkIdbIsInstalled();
     return wrapWithErrorMessage(
         cp
-            .execToString(
-                `${idbPath} --log ${idbLogLevel} file push --udid ${udid} --bundle-id ${bundleId} '${src}' '${dst}'`,
-            )
+            .execFileToString(idbPath, [
+                "--log",
+                idbLogLevel,
+                "file",
+                "push",
+                "--udid",
+                udid,
+                "--bundle-id",
+                bundleId,
+                src,
+                dst,
+            ])
             .then(() => {
                 return;
             })
@@ -204,9 +213,18 @@ async function pull(
     await checkIdbIsInstalled();
     return wrapWithErrorMessage(
         cp
-            .execToString(
-                `${idbPath} --log ${idbLogLevel} file pull --udid ${udid} --bundle-id ${bundleId} '${src}' '${dst}'`,
-            )
+            .execFileToString(idbPath, [
+                "--log",
+                idbLogLevel,
+                "file",
+                "pull",
+                "--udid",
+                udid,
+                "--bundle-id",
+                bundleId,
+                src,
+                dst,
+            ])
             .then(() => {
                 return;
             })

--- a/src/extension/networkInspector/certificateProvider.ts
+++ b/src/extension/networkInspector/certificateProvider.ts
@@ -405,8 +405,12 @@ export class CertificateProvider {
     ): Promise<string> {
         const matches = /\/Devices\/([^/]+)\//.exec(deviceCsrFilePath);
         if (matches && matches.length == 2) {
+            const udid = matches[1];
+            if (!/^[A-F0-9-]{25,40}$/i.test(udid)) {
+                return Promise.reject(new Error(`Invalid iOS device UDID: ${udid}`));
+            }
             // It's a simulator, the deviceId is in the filepath.
-            return Promise.resolve(matches[1]);
+            return Promise.resolve(udid);
         }
         return iosUtil.targets().then(targets => {
             if (targets.length === 0) {


### PR DESCRIPTION
- Validate extracted iOS device UDID format before use in downstream operations.
- Refactor idb file push/pull to use execFile with argument arrays instead of string concatenation via execToString.