### PR TITLE
Add Origin header validation to CDP proxy WebSocket server

### DIFF
--- a/src/cdp-proxy/reactNativeCDPProxy.ts
+++ b/src/cdp-proxy/reactNativeCDPProxy.ts
@@ -101,7 +101,7 @@ export class ReactNativeCDPProxy {
         // raw WebSocket client). Browser-initiated WebSocket connections always include
         // an Origin header and should be rejected.
         if (request.headers.origin) {
-            debuggerTarget.close();
+            await debuggerTarget.close();
             return;
         }
 

--- a/src/cdp-proxy/reactNativeCDPProxy.ts
+++ b/src/cdp-proxy/reactNativeCDPProxy.ts
@@ -97,6 +97,14 @@ export class ReactNativeCDPProxy {
         Connection,
         IncomingMessage,
     ]): Promise<void> {
+        // Only allow connections without an Origin header (i.e., from vscode-js-debug's
+        // raw WebSocket client). Browser-initiated WebSocket connections always include
+        // an Origin header and should be rejected.
+        if (request.headers.origin) {
+            debuggerTarget.close();
+            return;
+        }
+
         this.debuggerTarget = debuggerTarget;
 
         this.debuggerTarget.pause(); // don't listen for events until the target is ready


### PR DESCRIPTION
Reject WebSocket connections that include an Origin header in the CDP proxy. Only the raw vscode-js-debug WebSocket client should connect to the proxy, and it does not send an Origin header.