### PR TITLE
Bind debug adapter server to loopback address

### DIFF
--- a/src/extension/reactNativeSessionManager.ts
+++ b/src/extension/reactNativeSessionManager.ts
@@ -45,7 +45,7 @@ export class ReactNativeSessionManager
             });
         }
 
-        debugServer.listen(0);
+        debugServer.listen(0, "127.0.0.1");
         this.servers.set(session.id, debugServer);
 
         // make VS Code connect to debug server


### PR DESCRIPTION
Bind the DAP TCP server to 127.0.0.1 instead of all interfaces. Only the local VS Code process connects to this server.