### PR TITLE
Fix security vulnerability: override istanbul-lib-processinfo uuid to 11.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7619,13 +7619,17 @@
       }
     },
     "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/istanbul-lib-report": {
@@ -18574,7 +18578,7 @@
         "make-dir": "^3.0.0",
         "p-map": "^3.0.0",
         "rimraf": "^3.0.0",
-        "uuid": "^3.3.3"
+        "uuid": "11.1.1"
       },
       "dependencies": {
         "p-map": {
@@ -18587,9 +18591,9 @@
           }
         },
         "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+          "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -1550,6 +1550,9 @@
     "serialize-javascript": "7.0.5",
     "mochawesome": {
       "uuid": "11.1.1"
+    },
+    "istanbul-lib-processinfo": {
+      "uuid": "11.1.1"
     }
   }
 }


### PR DESCRIPTION
## Summary
Upgrade the remaining vulnerable uuid transitive dependency to 11.1.1 via npm overrides to address Dependabot alert #352.

## Proposed Changes
- Add an istanbul-lib-processinfo > uuid override to 11.1.1.
- Keep the existing mochawesome > uuid override unchanged.
- Refresh package-lock.json so the nested uuid dependency resolves to 11.1.1.

## Test Plan
- Verify node_modules/istanbul-lib-processinfo/node_modules/uuid is 11.1.1 after npm install.

Closes #2672