### PR TITLE
Remove unused deprecated XDL fields

### DIFF
--- a/src/typings/exponent/xdl.d.ts
+++ b/src/typings/exponent/xdl.d.ts
@@ -56,12 +56,10 @@ declare namespace xdl {
     interface SDKVersion {
         androidExpoViewUrl?: string;
         expoReactNativeTag: string;
-        /* deprecated */ exponentReactNativeTag?: string;
         expokitNpmPackage?: string;
         facebookReactNativeVersion: string;
         facebookReactVersion?: string;
         iosExpoViewUrl?: string;
-        /* deprecated */ iosExponentViewUrl?: string;
         iosVersion?: string;
         isDeprecated?: boolean;
         packagesToInstallWhenEjecting?: { [name: string]: string };


### PR DESCRIPTION
## Summary
- Remove unused deprecated XDL SDKVersion fields from xdl.d.ts
- Keep the current replacement fields expoReactNativeTag and iosExpoViewUrl

## Validation
- rg "exponentReactNativeTag|iosExponentViewUrl" src test returns no matches
- npx gulp format
- npm run build

Closes #2679