### PR TITLE
Add security validation unit tests

### DIFF
--- a/src/extension/networkInspector/certificateProvider.ts
+++ b/src/extension/networkInspector/certificateProvider.ts
@@ -332,11 +332,11 @@ export class CertificateProvider {
     }
 
     private validateDestinationPath(destination: string, os: ClientOS): void {
-        const resolved = path.resolve(destination);
-        if (resolved.includes("..")) {
+        if (destination.split(/[\\/]+/).includes("..")) {
             throw new Error(`Path traversal not allowed in destination: ${destination}`);
         }
 
+        const resolved = path.resolve(destination);
         const allowedPrefixes: string[] = [];
         if (os === ClientOS.iOS) {
             allowedPrefixes.push(

--- a/test/cdp-proxy/reactNativeCDPProxy.test.ts
+++ b/test/cdp-proxy/reactNativeCDPProxy.test.ts
@@ -27,6 +27,7 @@ import {
     mockResults,
 } from "./cdpConstants";
 import { PromiseUtil } from "../../src/common/node/promise";
+import Sinon = require("sinon");
 
 suite("reactNativeCDPProxy", function () {
     const cdpProxyHostAddress = "127.0.0.1"; // localhost
@@ -237,6 +238,84 @@ suite("reactNativeCDPProxy", function () {
 
                 assert.deepStrictEqual(messageFromDebugger, resultMessage);
             });
+        });
+    });
+
+    suite("Origin validation", () => {
+        function createConnectionStub(): any {
+            return {
+                close: Sinon.stub().returns(Promise.resolve()),
+                pause: Sinon.stub(),
+                unpause: Sinon.stub(),
+                onError: Sinon.stub(),
+                onCommand: Sinon.stub(),
+                onReply: Sinon.stub(),
+                onEnd: Sinon.stub(),
+            };
+        }
+
+        function createTransportStub(): any {
+            return {
+                close: Sinon.stub().returns(Promise.resolve()),
+                send: Sinon.stub(),
+                onMessage: Sinon.stub(),
+                onError: Sinon.stub(),
+                onEnd: Sinon.stub(),
+            };
+        }
+
+        test("should close debugger connections that include an Origin header", async () => {
+            const localProxy = new ReactNativeCDPProxy(
+                cdpProxyHostAddress,
+                generateRandomPortNumber(),
+            );
+            const debuggerTarget = createConnectionStub();
+
+            await (localProxy as any).onConnectionHandler([
+                debuggerTarget,
+                {
+                    headers: {
+                        origin: "https://example.com",
+                    },
+                },
+            ]);
+
+            assert.strictEqual(debuggerTarget.close.calledOnce, true);
+            assert.strictEqual(debuggerTarget.pause.called, false);
+        });
+
+        test("should continue debugger connections without an Origin header", async () => {
+            const localProxy = new ReactNativeCDPProxy(
+                cdpProxyHostAddress,
+                generateRandomPortNumber(),
+            );
+            const debuggerTarget = createConnectionStub();
+            const createWebSocketTransportStub = Sinon.stub(WebSocketTransport, "create").returns(
+                Promise.resolve(createTransportStub()),
+            );
+
+            Object.assign(localProxy, {
+                browserInspectUri: "ws://localhost:1234/debugger",
+                CDPMessageHandler: {
+                    setApplicationTarget: Sinon.stub(),
+                    setDebuggerTarget: Sinon.stub(),
+                },
+            });
+
+            try {
+                await (localProxy as any).onConnectionHandler([
+                    debuggerTarget,
+                    {
+                        headers: {},
+                    },
+                ]);
+            } finally {
+                createWebSocketTransportStub.restore();
+            }
+
+            assert.strictEqual(debuggerTarget.close.called, false);
+            assert.strictEqual(debuggerTarget.pause.calledOnce, true);
+            assert.strictEqual(debuggerTarget.unpause.calledOnce, true);
         });
     });
 });

--- a/test/extension/commands/installExpoGoApplication.test.ts
+++ b/test/extension/commands/installExpoGoApplication.test.ts
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+import assert = require("assert");
+import { EventEmitter } from "events";
+import Sinon = require("sinon");
+import proxyquire = require("proxyquire");
+
+suite("installExpoGoApplicationCommand", function () {
+    function createMockProject(projectPath: string): any {
+        return {
+            getExponentHelper: () => ({
+                isExpoManagedApp: Sinon.stub().returns(Promise.resolve(true)),
+                exponentSdk: Sinon.stub().returns(Promise.resolve("50.0.0")),
+            }),
+            getPackager: () => ({
+                getProjectPath: () => projectPath,
+            }),
+        };
+    }
+
+    function createCommandModule(
+        androidClientVersion: string,
+        downloadExpoGoStub: Sinon.SinonStub,
+    ) {
+        const response = new EventEmitter() as any;
+        response.setEncoding = Sinon.stub();
+
+        const request = new EventEmitter() as any;
+        request.end = Sinon.stub();
+
+        const getStub = ((_url: string, callback: (response: any) => void) => {
+            callback(response);
+            process.nextTick(() => {
+                response.emit(
+                    "data",
+                    JSON.stringify({
+                        sdkVersions: {
+                            "50.0.0": {
+                                androidClientUrl: "https://example.com/expo.apk",
+                                androidClientVersion,
+                                iosClientUrl: "https://example.com/expo.tar.gz",
+                                iosClientVersion: "2.0.0",
+                            },
+                        },
+                    }),
+                );
+                response.emit("end");
+            });
+            return request;
+        }) as any;
+
+        const showQuickPickStub = Sinon.stub();
+        showQuickPickStub.onFirstCall().returns(Promise.resolve("Android"));
+        showQuickPickStub.onSecondCall().returns(Promise.resolve("Manual"));
+
+        const logger = {
+            info: Sinon.stub(),
+            error: Sinon.stub(),
+            warning: Sinon.stub(),
+            debug: Sinon.stub(),
+            logStream: Sinon.stub(),
+        };
+
+        const module = proxyquire.noCallThru()(
+            "../../../src/extension/commands/installExpoGoApplication",
+            {
+                vscode: {
+                    window: {
+                        showQuickPick: showQuickPickStub,
+                        showInformationMessage: Sinon.stub(),
+                    },
+                },
+                https: {
+                    get: getStub,
+                },
+                "../../common/downloadHelper": {
+                    downloadExpoGo: downloadExpoGoStub,
+                },
+                "../../common/installHelper": {
+                    installAndroidApplication: Sinon.stub().returns(Promise.resolve()),
+                    installiOSApplication: Sinon.stub().returns(Promise.resolve()),
+                },
+                "../log/OutputChannelLogger": {
+                    OutputChannelLogger: {
+                        getMainChannel: () => logger,
+                    },
+                },
+            },
+        ) as typeof import("../../../src/extension/commands/installExpoGoApplication");
+
+        return {
+            InstallExpoGoApplication: module.InstallExpoGoApplication,
+            getStub,
+        };
+    }
+
+    async function runCommand(
+        commandClass: typeof import("../../../src/extension/commands/installExpoGoApplication").InstallExpoGoApplication,
+    ): Promise<void> {
+        const command = commandClass.formInstance();
+        (command as any).project = createMockProject("/workspace/app");
+        await command.baseFn();
+    }
+
+    test("should reject non-numeric Expo Go version strings", async function () {
+        const downloadExpoGoStub = Sinon.stub().returns(Promise.resolve());
+        const { InstallExpoGoApplication } = createCommandModule(
+            "2.0.0;rm -rf /",
+            downloadExpoGoStub,
+        );
+
+        await assert.rejects(
+            runCommand(InstallExpoGoApplication),
+            /Invalid Expo Go version string: 2\.0\.0;rm -rf \//,
+        );
+        assert.strictEqual(downloadExpoGoStub.called, false);
+    });
+
+    test("should use valid Expo Go version strings in the download path", async function () {
+        const downloadExpoGoStub = Sinon.stub().returns(Promise.resolve());
+        const { InstallExpoGoApplication } = createCommandModule("2.0.0", downloadExpoGoStub);
+
+        await runCommand(InstallExpoGoApplication);
+
+        assert.strictEqual(downloadExpoGoStub.calledOnce, true);
+        assert.deepStrictEqual(downloadExpoGoStub.firstCall.args, [
+            "https://example.com/expo.apk",
+            "/workspace/app/expogo_2.0.0.apk",
+        ]);
+    });
+});

--- a/test/extension/networkInspector/certificateProvider.test.ts
+++ b/test/extension/networkInspector/certificateProvider.test.ts
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+import assert = require("assert");
+import * as path from "path";
+import proxyquire = require("proxyquire");
+import { ClientOS } from "../../../src/extension/networkInspector/clientUtils";
+
+suite("certificateProvider", function () {
+    function createCertificateProviderModule() {
+        const logger = {
+            info: () => {},
+            warning: () => {},
+            error: () => {},
+            debug: () => {},
+        };
+
+        const module = proxyquire.noCallThru()(
+            "../../../src/extension/networkInspector/certificateProvider",
+            {
+                "../../common/opensslWrapperWithPromises": {
+                    openssl: () => Promise.resolve(""),
+                    isInstalled: () => true,
+                },
+                "../log/OutputChannelLogger": {
+                    OutputChannelLogger: {
+                        getChannel: () => logger,
+                    },
+                },
+            },
+        ) as typeof import("../../../src/extension/networkInspector/certificateProvider");
+
+        return {
+            CertificateProvider: module.CertificateProvider,
+        };
+    }
+
+    function createProvider() {
+        const { CertificateProvider } = createCertificateProviderModule();
+        return new CertificateProvider({} as any) as any;
+    }
+
+    function getIOSAllowedDestination(): string {
+        return path.join(
+            process.env.HOME || "/Users",
+            "Library",
+            "Developer",
+            "CoreSimulator",
+            "Devices",
+            "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+            "data",
+            "Containers",
+            "Data",
+            "Application",
+            "FFFFFFFF-GGGG-HHHH-IIII-JJJJJJJJJJJJ",
+            "Documents",
+        );
+    }
+
+    test("should reject destination path traversal attempts", function () {
+        const provider = createProvider();
+        const traversalDestination = `${getIOSAllowedDestination()}${path.sep}..${
+            path.sep
+        }Documents`;
+
+        assert.throws(() => {
+            provider.validateDestinationPath(traversalDestination, ClientOS.iOS);
+        }, /Path traversal not allowed in destination/);
+    });
+
+    test("should allow iOS destinations under the simulator devices directory", function () {
+        const provider = createProvider();
+
+        assert.doesNotThrow(() => {
+            provider.validateDestinationPath(getIOSAllowedDestination(), ClientOS.iOS);
+        });
+    });
+
+    test("should reject iOS destinations outside the allowed simulator directory", function () {
+        const provider = createProvider();
+
+        assert.throws(() => {
+            provider.validateDestinationPath(path.join(process.cwd(), "Documents"), ClientOS.iOS);
+        }, /Destination path is not within an allowed directory/);
+    });
+});

--- a/test/index.ts
+++ b/test/index.ts
@@ -115,7 +115,11 @@ export async function run(): Promise<void> {
     };
 
     // Exclude smoke test bundle and localization driver; only run unit/integration tests here
-    return getTestFiles("extension/**/*.test.js", testsRoot)
+    return Promise.all([
+        getTestFiles("extension/**/*.test.js", testsRoot),
+        getTestFiles("cdp-proxy/**/*.test.js", testsRoot),
+    ])
+        .then(testFileGroups => testFileGroups.flat())
         .then(files => files.filter(f => !/[\\/]exponent[\\/]/i.test(f)))
         .then(files => {
             files.forEach(f => mocha.addFile(path.resolve(testsRoot, f)));


### PR DESCRIPTION
## Summary
- Add unit tests for certificate destination path validation, including explicit traversal rejection and iOS simulator path allow/deny cases.
- Add Expo Go version validation coverage through the install command flow for rejected non-numeric versions and valid download paths.
- Add CDP proxy Origin-header validation tests and include CDP proxy tests in the standard extension test runner.

## Validation
- npm run build
- npm test

Closes #2688