### PR TITLE
security: bump js-yaml override to 4.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8656,10 +8656,20 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -14797,7 +14807,7 @@
         "globals": "^12.1.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
-        "js-yaml": "4.1.1",
+        "js-yaml": "4.2.0",
         "lodash": "^4.17.20",
         "minimatch": "^3.0.5",
         "strip-json-comments": "^3.1.1"
@@ -14976,7 +14986,7 @@
         "camelcase": "^5.3.1",
         "find-up": "^4.1.0",
         "get-package-type": "^0.1.0",
-        "js-yaml": "4.1.1",
+        "js-yaml": "4.2.0",
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
@@ -15292,7 +15302,7 @@
         "@textlint/types": "15.7.1",
         "chalk": "^4.1.2",
         "debug": "^4.4.3",
-        "js-yaml": "4.1.1",
+        "js-yaml": "4.2.0",
         "lodash": "^4.18.1",
         "pluralize": "^2.0.0",
         "string-width": "^4.2.3",
@@ -18158,7 +18168,7 @@
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
-        "js-yaml": "4.1.1",
+        "js-yaml": "4.2.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash": "^4.17.20",
@@ -19828,7 +19838,7 @@
             "find-up": "^5.0.0",
             "glob": "^8.1.0",
             "he": "^1.2.0",
-            "js-yaml": "4.1.1",
+            "js-yaml": "4.2.0",
             "log-symbols": "^4.1.0",
             "minimatch": "^5.1.6",
             "ms": "^2.1.3",
@@ -20778,9 +20788,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
       "requires": {
         "argparse": "^2.0.1"
@@ -21380,7 +21390,7 @@
         "glob": "^10.4.5",
         "he": "^1.2.0",
         "is-path-inside": "^3.0.3",
-        "js-yaml": "4.1.1",
+        "js-yaml": "4.2.0",
         "log-symbols": "^4.1.0",
         "minimatch": "^9.0.5",
         "ms": "^2.1.3",
@@ -22771,7 +22781,7 @@
       "dev": true,
       "requires": {
         "debug": "^4.4.3",
-        "js-yaml": "4.1.1",
+        "js-yaml": "4.2.0",
         "json5": "^2.2.3",
         "require-from-string": "^2.0.2"
       },

--- a/package.json
+++ b/package.json
@@ -1546,7 +1546,7 @@
     "ms-vscode.js-debug"
   ],
   "overrides": {
-    "js-yaml": "4.1.1",
+    "js-yaml": "4.2.0",
     "serialize-javascript": "7.0.5",
     "mochawesome": {
       "uuid": "11.1.1"


### PR DESCRIPTION
##    Résumé
Bump the `js-yaml` override from `4.1.1` to `4.2.0` to address Dependabot alert #359 (quadratic-complexity DoS via repeated aliases in merge keys).

## Proposed Changes
- `package.json`: update `overrides["js-yaml"]` to `4.2.0`
- `package-lock.json`: regenerated

## Test Plan
- `node_modules/js-yaml` resolves to `4.2.0`
- No functional code changes

Closes #2736