### PR TITLE
Add ScriptImporter URL unit tests

### DIFF
--- a/test/debugger/scriptImporter.test.ts
+++ b/test/debugger/scriptImporter.test.ts
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+import assert = require("assert");
+import { ScriptImporter } from "../../src/debugger/scriptImporter";
+
+suite("scriptImporter", function () {
+    let scriptImporter: ScriptImporter;
+
+    setup(function () {
+        scriptImporter = new ScriptImporter("localhost", 8081, "sources");
+    });
+
+    suite("prepareDebuggerWorkerURL", function () {
+        test("returns the legacy worker URL for RN versions before 0.50", function () {
+            assert.strictEqual(
+                scriptImporter.prepareDebuggerWorkerURL("0.49.0"),
+                "http://localhost:8081/debuggerWorker.js",
+            );
+        });
+
+        test("returns the debugger UI worker URL for RN 0.50 and later", function () {
+            assert.strictEqual(
+                scriptImporter.prepareDebuggerWorkerURL("0.50.0"),
+                "http://localhost:8081/debugger-ui/debuggerWorker.js",
+            );
+        });
+
+        test("returns the debugger UI worker URL for canary RN versions", function () {
+            assert.strictEqual(
+                scriptImporter.prepareDebuggerWorkerURL("0.0.0"),
+                "http://localhost:8081/debugger-ui/debuggerWorker.js",
+            );
+        });
+
+        test("uses the explicit debugger worker URL path when provided", function () {
+            assert.strictEqual(
+                scriptImporter.prepareDebuggerWorkerURL("0.55.4", ""),
+                "http://localhost:8081/debuggerWorker.js",
+            );
+            assert.strictEqual(
+                scriptImporter.prepareDebuggerWorkerURL("0.55.4", "new-debugger/"),
+                "http://localhost:8081/new-debugger/debuggerWorker.js",
+            );
+            assert.strictEqual(
+                scriptImporter.prepareDebuggerWorkerURL("0.49.0", "debugger-ui/"),
+                "http://localhost:8081/debugger-ui/debuggerWorker.js",
+            );
+        });
+    });
+
+    suite("overridePackagerPort", function () {
+        test("replaces localhost URL port without changing query string", function () {
+            assert.strictEqual(
+                (<any>scriptImporter).overridePackagerPort(
+                    "http://localhost:19000/index.bundle?platform=ios&dev=true&minify=false",
+                ),
+                "http://localhost:8081/index.bundle?platform=ios&dev=true&minify=false",
+            );
+        });
+    });
+});

--- a/test/index.ts
+++ b/test/index.ts
@@ -116,6 +116,7 @@ export async function run(): Promise<void> {
 
     // Exclude smoke test bundle and localization driver; only run unit/integration tests here
     return Promise.all([
+        getTestFiles("debugger/scriptImporter.test.js", testsRoot),
         getTestFiles("extension/**/*.test.js", testsRoot),
         getTestFiles("cdp-proxy/**/*.test.js", testsRoot),
     ])


### PR DESCRIPTION
## Summary
- Add focused unit tests for ScriptImporter debugger worker URL construction across legacy, debugger UI, canary, and explicit path cases.
- Include the new ScriptImporter test in the VS Code test runner without enabling the full debugger test directory.
- Cover packager port replacement while preserving URL query strings.

## Test Plan
- npx gulp format
- npx tsc --noEmit
- npm test (ScriptImporter tests passed; existing unrelated settings/android tests failed with timeout/channel-closed errors)

Closes #2716