### PR TITLE
Fix npm dependency issue in smoke tests pipeline

### DIFF
--- a/.ci/smoke-tests-common-validation.yml
+++ b/.ci/smoke-tests-common-validation.yml
@@ -1,4 +1,10 @@
 steps:
+  - task: NodeTool@0
+    displayName: "Use Node 20.x"
+    inputs:
+      versionSpec: 20.x
+  - bash: npm ci
+    displayName: "npm ci"
   - script: ./node_modules/.bin/gulp release --nightly --no-yarn --no-prepublish
     displayName: "gulp release"
   - task: CopyFiles@2


### PR DESCRIPTION
- Add NodeTool@0 task to ensure Node 20.x is available
- Add npm ci step before gulp release in smoke-tests-common-validation.yml
- Fixes: './node_modules/.bin/gulp: No such file or directory' error
- Prevents pipeline failures on PR and nightly builds

The smoke tests pipeline was failing because it tried to run gulp without ensuring npm dependencies were installed. Now npm ci is executed before any gulp commands.