### PR TITLE
Add OpenExpoUpgradeHelper command unit tests

### DIFF
--- a/test/extension/commands/openExpoUpgradeHelper.test.ts
+++ b/test/extension/commands/openExpoUpgradeHelper.test.ts
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+
+import assert = require("assert");
+import Sinon = require("sinon");
+import proxyquire = require("proxyquire");
+
+suite("openExpoUpgradeHelperCommand", function () {
+    const expoUpgradeUrl = "https://docs.expo.dev/bare/upgrade";
+
+    function createCommandModule(openExternalStub = Sinon.stub().returns(Promise.resolve())) {
+        const parsedUri = {};
+        const parseStub = Sinon.stub().returns(parsedUri);
+        const logger = { info: Sinon.stub() };
+
+        class FakeCommand {
+            static formInstance(): any {
+                return new this();
+            }
+        }
+
+        const module = proxyquire.noCallThru()(
+            "../../../src/extension/commands/openExpoUpgradeHelper",
+            {
+                vscode: {
+                    env: { openExternal: openExternalStub },
+                    Uri: { parse: parseStub },
+                },
+                "../log/OutputChannelLogger": {
+                    OutputChannelLogger: {
+                        getMainChannel: () => logger,
+                    },
+                },
+                "./util/command": { Command: FakeCommand },
+            },
+        ) as typeof import("../../../src/extension/commands/openExpoUpgradeHelper");
+
+        return {
+            openExpoUpgradeHelper: module.openExpoUpgradeHelper,
+            parsedUri,
+            parseStub,
+            openExternalStub,
+            logger,
+        };
+    }
+
+    test("should expose the registered command metadata", function () {
+        const { openExpoUpgradeHelper } = createCommandModule();
+        const command = openExpoUpgradeHelper.formInstance();
+
+        assert.strictEqual(command.codeName, "openExpoUpgradeHelper");
+        assert.strictEqual(command.label, "Open expo upgrade helper in web page");
+    });
+
+    test("should open the Expo upgrade helper", async function () {
+        const { openExpoUpgradeHelper, parsedUri, parseStub, openExternalStub, logger } =
+            createCommandModule();
+        const command = openExpoUpgradeHelper.formInstance();
+        (command as any).project = {};
+
+        await command.baseFn();
+
+        assert.strictEqual(parseStub.calledWithExactly(expoUpgradeUrl), true);
+        assert.strictEqual(openExternalStub.calledWithExactly(parsedUri), true);
+        assert.strictEqual(
+            logger.info.calledWithExactly("Open expo upgrade helper in web browser."),
+            true,
+        );
+    });
+
+    test("should propagate errors from opening the Expo upgrade helper", async function () {
+        const error = new Error("failed to open URL");
+        const openExternalStub = Sinon.stub().returns(Promise.reject(error));
+        const { openExpoUpgradeHelper } = createCommandModule(openExternalStub);
+        const command = openExpoUpgradeHelper.formInstance();
+        (command as any).project = {};
+
+        await assert.rejects(() => command.baseFn(), error);
+    });
+
+    test("should require a project before opening the Expo upgrade helper", async function () {
+        const { openExpoUpgradeHelper, parseStub, openExternalStub, logger } =
+            createCommandModule();
+        const command = openExpoUpgradeHelper.formInstance();
+
+        await assert.rejects(() => command.baseFn(), assert.AssertionError);
+
+        assert.strictEqual(parseStub.called, false);
+        assert.strictEqual(openExternalStub.called, false);
+        assert.strictEqual(logger.info.called, false);
+    });
+});


### PR DESCRIPTION
## Summary

Add focused unit coverage for the existing `OpenExpoUpgradeHelper` command without changing production behavior.

## Changes

- Verify the command metadata.
- Verify the Expo upgrade URL is parsed and opened.
- Verify errors from `vscode.env.openExternal` propagate.
- Verify a project is required before the command accesses VS Code APIs.

## Validation

- `npx prettier --check test\\extension\\commands\\openExpoUpgradeHelper.test.ts` passed.
- `npm run build` passed with 0 ESLint errors.
- The new Extension Host suite passed all 4 tests with 0 failures.
- Full `npm test` had two unrelated existing failures: the command-registration activation issue tracked by #2839 and an intermittent 2-second timeout in `androidPlatform`.

Closes #2838