### PR TITLE
Fix extension activation circular dependency

### DIFF
--- a/src/common/packageLoader.ts
+++ b/src/common/packageLoader.ts
@@ -3,7 +3,7 @@
 
 import * as path from "path";
 import { OutputChannelLogger } from "../extension/log/OutputChannelLogger";
-import { AppLauncher } from "../extension/appLauncher";
+import { ProjectsStorage } from "../extension/projectsStorage";
 import { CommandExecutor, CommandVerbosity } from "./commandExecutor";
 import customRequire from "./customRequire";
 import { findFileInFolderHierarchy, getVersionFromExtensionNodeModules } from "./extensionHelper";
@@ -65,7 +65,8 @@ export class PackageLoader {
     }
 
     public installGlobalPackage(packageConfig: PackageConfig, projectRoot: string): Promise<void> {
-        const nodeModulesRoot: string = AppLauncher.getNodeModulesRootByProjectPath(projectRoot);
+        const nodeModulesRoot: string =
+            ProjectsStorage.getFolderByProjectRootPath(projectRoot).getOrUpdateNodeModulesRoot();
         const commandExecutor = new CommandExecutor(nodeModulesRoot, projectRoot, this.logger);
 
         return commandExecutor.spawnWithProgress(

--- a/src/common/projectVersionHelper.ts
+++ b/src/common/projectVersionHelper.ts
@@ -4,7 +4,7 @@
 import { URL } from "url";
 import * as semver from "semver";
 import { ILaunchArgs, PlatformType } from "../extension/launchArgs";
-import { AppLauncher } from "../extension/appLauncher";
+import { ProjectsStorage } from "../extension/projectsStorage";
 import { ErrorHelper } from "./error/errorHelper";
 import { InternalErrorCode } from "./error/internalErrorCode";
 import { RN_VERSION_ERRORS } from "./error/versionError";
@@ -60,7 +60,10 @@ export class ProjectVersionHelper {
     ): Promise<string | null> {
         try {
             if (!nodeModulesRoot) {
-                nodeModulesRoot = AppLauncher.getNodeModulesRootByProjectPath(projectRoot);
+                nodeModulesRoot =
+                    ProjectsStorage.getFolderByProjectRootPath(
+                        projectRoot,
+                    ).getOrUpdateNodeModulesRoot();
             }
             const rnPackage = new Package(nodeModulesRoot);
             const rnPkgJson = await rnPackage
@@ -88,7 +91,10 @@ export class ProjectVersionHelper {
         nodeModulesRoot?: string,
     ): Promise<RNPackageVersions> {
         if (!nodeModulesRoot) {
-            nodeModulesRoot = AppLauncher.getNodeModulesRootByProjectPath(projectRoot);
+            nodeModulesRoot =
+                ProjectsStorage.getFolderByProjectRootPath(
+                    projectRoot,
+                ).getOrUpdateNodeModulesRoot();
         }
 
         try {
@@ -119,7 +125,10 @@ export class ProjectVersionHelper {
             ) !== -1
         ) {
             if (!nodeModulesRoot) {
-                nodeModulesRoot = AppLauncher.getNodeModulesRootByProjectPath(projectRoot);
+                nodeModulesRoot =
+                    ProjectsStorage.getFolderByProjectRootPath(
+                        projectRoot,
+                    ).getOrUpdateNodeModulesRoot();
             }
 
             try {

--- a/src/debugger/debugSessionBase.ts
+++ b/src/debugger/debugSessionBase.ts
@@ -14,9 +14,8 @@ import { ErrorHelper } from "../common/error/errorHelper";
 import { InternalErrorCode } from "../common/error/internalErrorCode";
 import { InternalError, NestedError } from "../common/error/internalError";
 import { ILaunchArgs, IRunOptions, PlatformType } from "../extension/launchArgs";
-import { AppLauncher } from "../extension/appLauncher";
+import type { AppLauncher } from "../extension/appLauncher";
 import { RNPackageVersions } from "../common/projectVersionHelper";
-import { SettingsHelper } from "../extension/settingsHelper";
 import { OutputChannelLogger } from "../extension/log/OutputChannelLogger";
 import { DeviceStatusIndicator } from "../extension/deviceStatusIndicator";
 import { RNSession } from "./debugSessionWrapper";
@@ -190,6 +189,13 @@ export abstract class DebugSessionBase extends LoggingDebugSession {
                 args.sourceMapRenames = false;
             }
 
+            /* eslint-disable @typescript-eslint/no-var-requires */
+            const { SettingsHelper } =
+                require("../extension/settingsHelper") as typeof import("../extension/settingsHelper");
+            const { AppLauncher: AppLauncherClass } =
+                require("../extension/appLauncher") as typeof import("../extension/appLauncher");
+            /* eslint-enable @typescript-eslint/no-var-requires */
+
             const projectRootPath = SettingsHelper.getReactNativeProjectRoot(args.cwd);
             const isReactProject = await ReactNativeProjectHelper.isReactNativeProject(
                 projectRootPath,
@@ -198,7 +204,7 @@ export abstract class DebugSessionBase extends LoggingDebugSession {
                 throw ErrorHelper.getInternalError(InternalErrorCode.NotInReactNativeFolderError);
             }
 
-            const appLauncher = await AppLauncher.getOrCreateAppLauncherByProjectRootPath(
+            const appLauncher = await AppLauncherClass.getOrCreateAppLauncherByProjectRootPath(
                 projectRootPath,
             );
             this.appLauncher = appLauncher;

--- a/src/extension/projectsStorage.ts
+++ b/src/extension/projectsStorage.ts
@@ -2,13 +2,24 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 
 import * as vscode from "vscode";
-import { AppLauncher } from "./appLauncher";
+import type { AppLauncher } from "./appLauncher";
 
 export class ProjectsStorage {
     public static readonly projectsCache: { [key: string]: AppLauncher } = {};
 
     public static addFolder(workspaceFolder: string, appLauncher: AppLauncher): void {
         this.projectsCache[workspaceFolder.toLowerCase()] = appLauncher;
+    }
+
+    public static getFolderByProjectRootPath(projectRootPath: string): AppLauncher {
+        const appLauncher = this.projectsCache[projectRootPath.toLowerCase()];
+        if (!appLauncher) {
+            throw new Error(
+                `Could not find AppLauncher by the project root path ${projectRootPath}`,
+            );
+        }
+
+        return appLauncher;
     }
 
     public static getFolder(workspaceFolder: vscode.WorkspaceFolder): AppLauncher {

--- a/test/extension/commandExecutor.test.ts
+++ b/test/extension/commandExecutor.test.ts
@@ -12,7 +12,7 @@ import { ConsoleLogger } from "../../src/extension/log/ConsoleLogger";
 import { Node } from "../../src/common/node/node";
 import { ChildProcess } from "../../src/common/node/childProcess";
 import { Crypto } from "../../src/common/node/crypto";
-import { AppLauncher } from "../../src/extension/appLauncher";
+import { ProjectsStorage } from "../../src/extension/projectsStorage";
 import { HostPlatform } from "../../src/common/hostPlatform";
 // import { HostPlatform } from "../../src/common/hostPlatform";
 
@@ -21,7 +21,7 @@ suite("commandExecutor", function () {
         const childProcessStubInstance = new ChildProcess();
         let childProcessStub: Sinon.SinonStub & ChildProcess;
 
-        let appLauncherStub: Sinon.SinonStub;
+        let projectsStorageStub: Sinon.SinonStub;
         const Log = new ConsoleLogger();
         const sampleReactNativeProjectDir = path.join(
             __dirname,
@@ -42,7 +42,7 @@ suite("commandExecutor", function () {
             });
 
             childProcessStub.restore();
-            appLauncherStub.restore();
+            projectsStorageStub.restore();
         });
 
         setup(() => {
@@ -50,11 +50,9 @@ suite("commandExecutor", function () {
                 .stub(Node, "ChildProcess")
                 .returns(childProcessStubInstance) as ChildProcess & Sinon.SinonStub;
 
-            appLauncherStub = sinon.stub(
-                AppLauncher,
-                "getNodeModulesRootByProjectPath",
-                (projectRoot: string) => nodeModulesRoot,
-            );
+            projectsStorageStub = sinon
+                .stub(ProjectsStorage, "getFolderByProjectRootPath")
+                .returns({ getOrUpdateNodeModulesRoot: () => nodeModulesRoot });
 
             nodeModulesRoot = sampleReactNativeProjectDir;
         });

--- a/test/extension/rn-extension.test.ts
+++ b/test/extension/rn-extension.test.ts
@@ -117,6 +117,7 @@ suite("rn-extension", function () {
         });
 
         test("Verify that the commands registered by Cordova extension are loaded", async () => {
+            await vscode.extensions.getExtension("msjsdiag.vscode-react-native")?.activate();
             const commandsAvailable: string[] = (await vscode.commands.getCommands(true)).filter(
                 (commandName: string) => commandName.includes("reactNative."),
             );


### PR DESCRIPTION
## Summary

- Fix the extension activation circular dependency by routing project node_modules lookup through ProjectsStorage and deferring runtime debugger dependencies.
- Ensure the extension is explicitly activated before asserting registered commands.
- Keep test process cleanup separate in #2855.

## Validation

- npx prettier --check
- npm run build
- npx gulp webpack-bundle
- commandsRegistered test passes
- Process cleanup and real adb/browser test isolation are tracked separately in #2855.


Closes #2839