### PR TITLE
Fix extension test process leaks

### DIFF
--- a/src/common/node/childProcess.ts
+++ b/src/common/node/childProcess.ts
@@ -136,7 +136,7 @@ export class ChildProcess {
         const spawnedProcess = this.childProcess.spawn(
             command,
             args,
-            Object.assign({}, options, { shell: true }),
+            Object.assign({ shell: true }, options),
         );
         const outcome: Promise<void> = new Promise((resolve, reject) => {
             spawnedProcess.once("error", (error: any) => {

--- a/src/extension/android/adb.ts
+++ b/src/extension/android/adb.ts
@@ -196,7 +196,9 @@ export class AdbHelper {
     }
 
     public startLogCat(adbParameters: string[]): ISpawnResult {
-        return this.childProcess.spawn(this.adbExecutable.replace(/"/g, ""), adbParameters);
+        return this.childProcess.spawn(this.adbExecutable.replace(/"/g, ""), adbParameters, {
+            shell: false,
+        });
     }
 
     public parseSdkLocation(fileContent: string, logger?: ILogger): string | null {

--- a/test/extension/android/androidPlatform.test.ts
+++ b/test/extension/android/androidPlatform.test.ts
@@ -3,6 +3,7 @@
 
 import * as fs from "fs";
 import * as path from "path";
+import { EventEmitter } from "events";
 import assert = require("assert");
 import { AndroidPlatform } from "../../../src/extension/android/androidPlatform";
 import { IAndroidRunOptions, PlatformType } from "../../../src/extension/launchArgs";
@@ -15,6 +16,7 @@ import { ProjectVersionHelper } from "../../../src/common/projectVersionHelper";
 import "should";
 import * as sinon from "sinon";
 import { SettingsHelper } from "../../../src/extension/settingsHelper";
+import { LogCatMonitorManager } from "../../../src/extension/android/logCatMonitorManager";
 import { rimrafAsync } from "../../common/utils";
 
 suite("androidPlatform", function () {
@@ -60,6 +62,7 @@ suite("androidPlatform", function () {
         let spawnReactCommandStub: Sinon.SinonStub;
         let getReactNativeVersionsStub: Sinon.SinonStub;
         let installAppInDeviceStub: Sinon.SinonStub;
+        let startLogCatStub: Sinon.SinonStub;
 
         let devices: any;
         let adbHelper: adb.AdbHelper;
@@ -73,6 +76,13 @@ suite("androidPlatform", function () {
             fileSystem = new FileSystem();
 
             adbHelper = new adb.AdbHelper(genericRunOptions.projectRoot, nodeModulesRoot);
+            startLogCatStub = sinon.stub(adb.AdbHelper.prototype, "startLogCat").returns({
+                spawnedProcess: { kill: sinon.stub() },
+                stdin: {},
+                stdout: new EventEmitter(),
+                stderr: new EventEmitter(),
+                outcome: new Promise<void>(() => {}),
+            });
             launchAppStub = sinon.stub(
                 adbHelper,
                 "launchApp",
@@ -167,6 +177,7 @@ suite("androidPlatform", function () {
         });
 
         teardown(async () => {
+            LogCatMonitorManager.cleanUp();
             // Delete existing React Native project after each test
             await rimrafAsync(projectsFolder, {});
             launchAppStub.restore();
@@ -178,6 +189,7 @@ suite("androidPlatform", function () {
             spawnReactCommandStub.restore();
             getReactNativeVersionsStub.restore();
             installAppInDeviceStub.restore();
+            startLogCatStub.restore();
             devices = [];
         });
 

--- a/test/extension/android/androidPlatform.test.ts
+++ b/test/extension/android/androidPlatform.test.ts
@@ -598,6 +598,34 @@ suite("androidPlatform", function () {
             assert.strictEqual(adbValue, "adb");
         });
     });
+
+    suite("AdbHelper", function () {
+        test("startLogCat should spawn adb directly with the provided parameters", function () {
+            const adbHelper = new adb.AdbHelper("", "node_modules");
+            const adbParameters = ["-s", "emulator-5554", "logcat", "ReactNativeJS:V"];
+            const spawnResult = {} as any;
+            const spawnStub = sinon
+                .stub((adbHelper as any).childProcess, "spawn")
+                .returns(spawnResult);
+            (adbHelper as any).adbExecutable = '"C:\\Android SDK\\platform-tools\\adb.exe"';
+
+            try {
+                const result = adbHelper.startLogCat(adbParameters);
+
+                assert.strictEqual(result, spawnResult);
+                assert.strictEqual(
+                    spawnStub.calledWithExactly(
+                        "C:\\Android SDK\\platform-tools\\adb.exe",
+                        adbParameters,
+                        { shell: false },
+                    ),
+                    true,
+                );
+            } finally {
+                spawnStub.restore();
+            }
+        });
+    });
 });
 
 function fillDevices(ids: string[]): any[] {

--- a/test/extension/appLauncher.test.ts
+++ b/test/extension/appLauncher.test.ts
@@ -7,10 +7,13 @@ import * as fs from "fs";
 import * as BrowserHelper from "@vscode/js-debug-browsers";
 import * as sinon from "sinon";
 import * as child_process from "child_process";
+import { EventEmitter } from "events";
 import * as os from "os";
 import { AppLauncher } from "../../src/extension/appLauncher";
 import { ProjectsStorage } from "../../src/extension/projectsStorage";
 import { Node } from "../../src/common/node/node";
+import { PlatformType } from "../../src/extension/launchArgs";
+import { BROWSER_TYPES } from "../../src/extension/debuggingConfiguration/debugConfigTypesAndConstants";
 suite("appLauncher", function () {
     const fsHelper = new Node.FileSystem();
 
@@ -166,20 +169,47 @@ suite("appLauncher", function () {
         test("expo web launch on edge browser", async function () {
             // test for windows only
             if (os.platform() === "win32") {
+                let appLauncherTest: AppLauncher;
+                let browserFinderStub: Sinon.SinonStub;
+                let spawnStub: Sinon.SinonStub;
+
+                teardown(() => {
+                    browserFinderStub?.restore();
+                    spawnStub?.restore();
+                    if (appLauncherTest) {
+                        ProjectsStorage.delFolder(appLauncherTest.getWorkspaceFolder());
+                    }
+                });
+
                 try {
                     const browserPath = {
                         path: "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe",
                     };
-                    const browserFinderStub = sinon.stub(
+                    browserFinderStub = sinon.stub(
                         BrowserHelper.EdgeBrowserFinder.prototype,
                         "findAll",
                     );
                     browserFinderStub.returns(Promise.resolve([browserPath]));
-                    child_process.spawn(browserPath.path, {
-                        detached: true,
-                        stdio: ["ignore"],
+                    const browserProcess = new EventEmitter() as child_process.ChildProcess;
+                    browserProcess.unref = sinon.stub();
+                    spawnStub = sinon.stub(child_process, "spawn").returns(browserProcess);
+
+                    appLauncherTest = await AppLauncher.getOrCreateAppLauncherByProjectRootPath(
+                        sampleReactNativeProjectDir,
+                    );
+                    await appLauncherTest.launchBrowser({
+                        platform: PlatformType.ExpoWeb,
+                        browserTarget: BROWSER_TYPES.Edge,
+                        port: 9222,
                     });
-                    browserFinderStub.restore();
+
+                    sinon.assert.calledOnce(spawnStub);
+                    sinon.assert.calledWith(
+                        spawnStub,
+                        browserPath.path,
+                        sinon.match.array,
+                        sinon.match({ detached: true, stdio: ["ignore"] }),
+                    );
                 } catch (err) {
                     assert.fail(err as any);
                 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -6,6 +6,11 @@
 import * as path from "path";
 import Mocha = require("mocha");
 import NYCPackage from "nyc";
+import { LogCatMonitorManager } from "../src/extension/android/logCatMonitorManager";
+
+function cleanUpTestProcesses(): void {
+    LogCatMonitorManager.cleanUp();
+}
 
 async function loadGlob(): Promise<any> {
     try {
@@ -42,6 +47,7 @@ function setupCoverage(): NYCPackage {
 
 export async function run(): Promise<void> {
     const nyc = process.env.COVERAGE ? setupCoverage() : null;
+    process.once("exit", cleanUpTestProcesses);
 
     // Provide harmless stubs for Mocha BDD hooks if some non-target test files
     // (e.g. smoke tests) get loaded indirectly before Mocha initialization.
@@ -140,6 +146,7 @@ export async function run(): Promise<void> {
             });
         })
         .finally(() => {
+            cleanUpTestProcesses();
             if (nyc) {
                 nyc.writeCoverageFile();
                 return nyc.report();


### PR DESCRIPTION
## Summary

- Stub adb logcat in Android platform tests so host tests do not launch real adb processes.
- Stub Edge spawning in the Expo web test so tests do not open a real browser.
- Clean up extension-owned LogCat monitors after Android tests and when the test runner exits.
- Start production adb logcat directly with shell disabled so the extension owns the process it terminates.
- Verify the adb executable, arguments, and shell option passed by AdbHelper.startLogCat.

## Safety

Cleanup only uses extension-owned monitor and child-process handles. It does not terminate adb servers, emulators, VS Code, Node, PowerShell, or browsers globally by process name.

## Validation

- npx prettier --check test\extension\android\androidPlatform.test.ts
- npm run build
- AdbHelper startLogCat parameter test passes in the Extension Host suite
- npm test: 307 tests executed, 1 skipped; one intermittent existing 2-second timeout occurred in packager.test.ts
- Relevant PID snapshot was unchanged before and after the run; no new adb logcat, repository Node, Extension Host, or Edge process remained

Closes #2855