### PR TITLE
Fix security vulnerability: bump js-yaml override to 4.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8595,9 +8595,9 @@
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "node_modules/js-yaml": {
-            "version": "4.3.0",
-            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-4.3.0.tgz",
-            "integrity": "sha1-0ZAFcqf3zwtfVAyDZz5gutNDZZI=",
+            "version": "4.3.1",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
             "dev": true,
             "funding": [
                 {
@@ -14685,7 +14685,7 @@
                 "globals": "^12.1.0",
                 "ignore": "^4.0.6",
                 "import-fresh": "^3.2.1",
-                "js-yaml": "4.3.0",
+                "js-yaml": "4.3.1",
                 "lodash": "^4.17.20",
                 "minimatch": "^3.0.5",
                 "strip-json-comments": "^3.1.1"
@@ -14864,7 +14864,7 @@
                 "camelcase": "^5.3.1",
                 "find-up": "^4.1.0",
                 "get-package-type": "^0.1.0",
-                "js-yaml": "4.3.0",
+                "js-yaml": "4.3.1",
                 "resolve-from": "^5.0.0"
             },
             "dependencies": {
@@ -15023,7 +15023,7 @@
                     "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.3",
-                        "fast-uri": "github:fastify/fast-uri#v3.1.5",
+                        "fast-uri": "3.1.5",
                         "json-schema-traverse": "^1.0.0",
                         "require-from-string": "^2.0.2"
                     }
@@ -15183,7 +15183,7 @@
                 "@textlint/types": "15.7.1",
                 "chalk": "^4.1.2",
                 "debug": "^4.4.3",
-                "js-yaml": "4.3.0",
+                "js-yaml": "4.3.1",
                 "lodash": "^4.18.1",
                 "pluralize": "^2.0.0",
                 "string-width": "^4.2.3",
@@ -16394,7 +16394,7 @@
                     "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.3",
-                        "fast-uri": "github:fastify/fast-uri#v3.1.5",
+                        "fast-uri": "3.1.5",
                         "json-schema-traverse": "^1.0.0",
                         "require-from-string": "^2.0.2"
                     }
@@ -18036,7 +18036,7 @@
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
-                "js-yaml": "4.3.0",
+                "js-yaml": "4.3.1",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
                 "lodash": "^4.17.20",
@@ -18735,7 +18735,7 @@
         "fast-uri": {
             "version": "git+ssh://git@github.com/fastify/fast-uri.git#5e179cbb4636d5f773ed21126e5bd3068e87e94e",
             "dev": true,
-            "from": "fast-uri@github:fastify/fast-uri#v3.1.5"
+            "from": "fast-uri@3.1.5"
         },
         "fastest-levenshtein": {
             "version": "1.0.16",
@@ -19696,7 +19696,7 @@
                         "find-up": "^5.0.0",
                         "glob": "^8.1.0",
                         "he": "^1.2.0",
-                        "js-yaml": "4.3.0",
+                        "js-yaml": "4.3.1",
                         "log-symbols": "^4.1.0",
                         "minimatch": "^5.1.6",
                         "ms": "^2.1.3",
@@ -20646,9 +20646,9 @@
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "js-yaml": {
-            "version": "4.3.0",
-            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-4.3.0.tgz",
-            "integrity": "sha1-0ZAFcqf3zwtfVAyDZz5gutNDZZI=",
+            "version": "4.3.1",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
             "dev": true,
             "requires": {
                 "argparse": "^2.0.1"
@@ -21242,7 +21242,7 @@
                 "glob": "^10.4.5",
                 "he": "^1.2.0",
                 "is-path-inside": "^3.0.3",
-                "js-yaml": "4.3.0",
+                "js-yaml": "4.3.1",
                 "log-symbols": "^4.1.0",
                 "minimatch": "^9.0.5",
                 "ms": "^2.1.3",
@@ -22633,7 +22633,7 @@
             "dev": true,
             "requires": {
                 "debug": "^4.4.3",
-                "js-yaml": "4.3.0",
+                "js-yaml": "4.3.1",
                 "json5": "^2.2.3",
                 "require-from-string": "^2.0.2"
             },
@@ -23035,7 +23035,7 @@
                     "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.3",
-                        "fast-uri": "github:fastify/fast-uri#v3.1.5",
+                        "fast-uri": "3.1.5",
                         "json-schema-traverse": "^1.0.0",
                         "require-from-string": "^2.0.2"
                     }

--- a/package.json
+++ b/package.json
@@ -1542,7 +1542,7 @@
         "@babel/core": "7.29.6",
         "brace-expansion": "github:juliangruber/brace-expansion#v5.0.9",
         "fast-uri": "3.1.5",
-        "js-yaml": "4.3.0",
+        "js-yaml": "4.3.1",
         "serialize-javascript": "7.0.5",
         "mochawesome": {
             "uuid": "11.1.1"


### PR DESCRIPTION
## Summary

Bumps the `js-yaml` override from `4.3.0` to `4.3.1` to fix a high-severity quadratic CPU consumption vulnerability (GHSA-5p4m-2wfm-xmqj, CVSS 7.5).

`js-yaml` 4.x uses a linear `Array.indexOf` scan inside the `!!omap` resolver loop, making resolution O(n²). A small crafted YAML document can block the Node.js event loop for several seconds. Version 4.3.1 replaces the linear scan with a `Set`, making resolution O(n).

## Proposed Changes

- Bump `js-yaml` `overrides` entry from `4.3.0` to `4.3.1` in `package.json`
- Update `package-lock.json` accordingly

## Test Plan

- Dependabot alert #389 should be resolved automatically after merge
- No functional changes; this is a transitive dependency override bump

Closes #2880