### PR TITLE
Replace deprecated source-map-resolve with a maintained alias

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
                 "rsocket-tcp-server": "0.0.23",
                 "semver": "6.3.1",
                 "source-map": "0.5.2",
-                "source-map-resolve": "0.5.3",
+                "source-map-resolve": "npm:@stackline/source-map-resolve@1.0.0",
                 "strip-json-comments": "2.0.1",
                 "tmp-promise": "3.0.2",
                 "uuid": "14.0.0",
@@ -11150,12 +11150,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/resolve-url": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-            "deprecated": "https://github.com/lydell/resolve-url#deprecated"
-        },
         "node_modules/restore-cursor": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -11765,16 +11759,17 @@
             }
         },
         "node_modules/source-map-resolve": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
-            "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
-            "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
+            "name": "@stackline/source-map-resolve",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@stackline/source-map-resolve/-/source-map-resolve-1.0.0.tgz",
+            "integrity": "sha512-DGaG+Qhu52BkyTkTqXRGdcA/FFE9nAr0Adl8cNdap3CqmmDslv26VjJej/zNhJkQAxKzlQKjUm8TWB06jXXTHw==",
+            "license": "MIT",
             "dependencies": {
-                "atob": "^2.1.2",
-                "decode-uri-component": "^0.2.0",
-                "resolve-url": "^0.2.1",
-                "source-map-url": "^0.4.0",
-                "urix": "^0.1.0"
+                "atob": "2.1.2",
+                "decode-uri-component": "0.2.2"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/source-map-support": {
@@ -11797,12 +11792,6 @@
             "engines": {
                 "node": ">=0.8.0"
             }
-        },
-        "node_modules/source-map-url": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
-            "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
-            "deprecated": "See https://github.com/lydell/source-map-url#deprecated"
         },
         "node_modules/sparkles": {
             "version": "2.1.0",
@@ -12897,12 +12886,6 @@
             "dependencies": {
                 "punycode": "^2.1.0"
             }
-        },
-        "node_modules/urix": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-            "deprecated": "Please see https://github.com/lydell/urix#deprecated"
         },
         "node_modules/url-join": {
             "version": "4.0.1",
@@ -21913,11 +21896,6 @@
             "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
             "dev": true
         },
-        "resolve-url": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
-        },
         "restore-cursor": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -22372,15 +22350,12 @@
             "integrity": "sha1-67bl6HQk9Jetb5csY4nqzzwMvgA="
         },
         "source-map-resolve": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
-            "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+            "version": "npm:@stackline/source-map-resolve@1.0.0",
+            "resolved": "https://registry.npmjs.org/@stackline/source-map-resolve/-/source-map-resolve-1.0.0.tgz",
+            "integrity": "sha512-DGaG+Qhu52BkyTkTqXRGdcA/FFE9nAr0Adl8cNdap3CqmmDslv26VjJej/zNhJkQAxKzlQKjUm8TWB06jXXTHw==",
             "requires": {
-                "atob": "^2.1.2",
-                "decode-uri-component": "^0.2.0",
-                "resolve-url": "^0.2.1",
-                "source-map-url": "^0.4.0",
-                "urix": "^0.1.0"
+                "atob": "2.1.2",
+                "decode-uri-component": "0.2.2"
             }
         },
         "source-map-support": {
@@ -22402,11 +22377,6 @@
                     }
                 }
             }
-        },
-        "source-map-url": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
-            "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw=="
         },
         "sparkles": {
             "version": "2.1.0",
@@ -23258,11 +23228,6 @@
             "requires": {
                 "punycode": "^2.1.0"
             }
-        },
-        "urix": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
         },
         "url-join": {
             "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -1447,7 +1447,7 @@
         "rsocket-tcp-server": "0.0.23",
         "semver": "6.3.1",
         "source-map": "0.5.2",
-        "source-map-resolve": "0.5.3",
+        "source-map-resolve": "npm:@stackline/source-map-resolve@1.0.0",
         "strip-json-comments": "2.0.1",
         "tmp-promise": "3.0.2",
         "uuid": "14.0.0",


### PR DESCRIPTION
`sourceMapsCombinator` currently imports `source-map-resolve@0.5.3` and calls its synchronous `resolveSync` API while combining debugger source maps, including Windows drive-letter handling.

This changes only the existing dependency key and lockfile to the exact npm alias:

```json
"source-map-resolve": "npm:@stackline/source-map-resolve@1.0.0"
```

Imports, the existing drive-letter workaround, and the repository's ambient declaration remain unchanged. The replacement preserves the seven-function CommonJS API, synchronous and callback behavior, and error metadata; it supports the repository's Node 20 CI runtime and corrects Windows cross-drive path retention.

Disclosure: I maintain [`@stackline/source-map-resolve`](https://www.npmjs.com/package/@stackline/source-map-resolve). It is an MIT compatibility fork and is not affiliated with or endorsed by the original maintainer. This is a maintenance proposal, not a claim that a clean `source-map-resolve@0.5.3` installation is currently vulnerable.

Validation on the current base commit `5403c435aeb41fa4c3542490f37adab71782e5d4`:

- `npm ci`
- `npx gulp`
- `npm run build` — 0 errors; the same 157 existing warnings
- focused `sourceMapsCombinator` Mocha test — 1 passing
- `npm test -- --verbose` — 358 passing, 1 pending
- `npm run test-localization -- --verbose` — 2 passing when run after the required gulp/build sequence

The package separately characterizes shared ordinary behavior against 0.5.3, but does not reproduce that release's deprecated dependency topology or claim byte-for-byte 0.5.x equivalence. I retained the local type declaration to keep this migration focused; adopting the package's stricter first-party types can be evaluated separately.
